### PR TITLE
Basic scaffolding and notifier generator

### DIFF
--- a/lib/mix/tasks/phx.gen.auth.ex
+++ b/lib/mix/tasks/phx.gen.auth.ex
@@ -1,0 +1,63 @@
+defmodule Mix.Tasks.Phx.Gen.Auth do
+  @shortdoc "Generates authentication logic for a resource"
+
+  @moduledoc """
+  Generates authentication logic for a resource
+
+    mix phx.gen.auth Accounts User users
+  """
+
+  use Mix.Task
+
+  alias Mix.Phoenix.{Context}
+  alias Mix.Tasks.Phx.Gen
+
+  @doc false
+  def run(args) do
+    {context, schema} = Gen.Context.build(args)
+    Gen.Context.prompt_for_code_injection(context)
+
+    binding = [context: context, schema: schema]
+    paths = generator_paths()
+
+    prompt_for_conflicts(context)
+
+    context
+    |> copy_new_files(binding, paths)
+    |> maybe_inject_helpers()
+    |> print_shell_instructions()
+  end
+
+  defp prompt_for_conflicts(context) do
+    context
+    |> files_to_be_generated()
+    |> Mix.Phoenix.prompt_for_conflicts()
+  end
+
+  defp files_to_be_generated(%Context{schema: schema} = context) do
+    [{:eex, "notifier.ex", Path.join([context.dir, "#{schema.singular}_notifier.ex"])}]
+  end
+
+  defp copy_new_files(%Context{} = context, binding, paths) do
+    files = files_to_be_generated(context)
+    Mix.Phoenix.copy_from(paths, "priv/templates/phx.gen.auth", binding, files)
+
+    context
+  end
+
+  defp maybe_inject_helpers(%Context{} = context) do
+    context
+  end
+
+  defp print_shell_instructions(%Context{} = context) do
+    context
+  end
+
+  # The paths to look for template files for generators.
+  #
+  # Defaults to checking the current app's `priv` directory,
+  # and falls back to phx_gen_auth's `priv` directory.
+  defp generator_paths do
+    [".", :phx_gen_auth]
+  end
+end

--- a/priv/templates/phx.gen.auth/notifier.ex
+++ b/priv/templates/phx.gen.auth/notifier.ex
@@ -1,0 +1,68 @@
+defmodule <%= inspect context.module %>.<%= inspect schema.alias %>Notifier do
+  # For simplicity, this module simply prints messages to the terminal.
+  # You should replace it by a proper e-mail or notification tool, such as:
+  #
+  #   * Swoosh - https://github.com/swoosh/swoosh
+  #   * Bamboo - https://github.com/thoughtbot/bamboo
+  #
+
+  @doc """
+  Deliver instructions to confirm account.
+  """
+  def deliver_confirmation_instructions(<%= schema.singular %>, url) do
+    IO.puts("""
+
+    ==============================
+
+    Hi #{<%= schema.singular %>.email},
+
+    You can confirm your account by visiting the url below:
+
+    #{url}
+
+    If you didn't create an account with us, please ignore this.
+
+    ==============================
+    """)
+  end
+
+  @doc """
+  Deliver instructions to reset password account.
+  """
+  def deliver_reset_password_instructions(<%= schema.singular %>, url) do
+    IO.puts("""
+
+    ==============================
+
+    Hi #{<%= schema.singular %>.email},
+
+    You can reset your password by visiting the url below:
+
+    #{url}
+
+    If you didn't request this change, please ignore this.
+
+    ==============================
+    """)
+  end
+
+  @doc """
+  Deliver instructions to update your e-mail.
+  """
+  def deliver_update_email_instructions(<%= schema.singular %>, url) do
+    IO.puts("""
+
+    ==============================
+
+    Hi #{<%= schema.singular %>.email},
+
+    You can change your e-mail by visiting the url below:
+
+    #{url}
+
+    If you didn't request this change, please ignore this.
+
+    ==============================
+    """)
+  end
+end

--- a/test/mix/tasks/phx.gen.live_test.exs
+++ b/test/mix/tasks/phx.gen.live_test.exs
@@ -1,0 +1,24 @@
+Code.require_file("../../mix_helper.exs", __DIR__)
+
+defmodule Mix.Tasks.Phx.Gen.AuthTest do
+  use ExUnit.Case
+
+  import MixHelper
+  alias Mix.Tasks.Phx.Gen
+
+  setup do
+    Mix.Task.clear()
+    :ok
+  end
+
+  test "generates auth logic", config do
+    in_tmp_project(config.test, fn ->
+      Gen.Auth.run(~w(Accounts User users))
+
+      assert_file("lib/phx_gen_auth/accounts/user_notifier.ex", fn file ->
+        assert file =~ "defmodule PhxGenAuth.Accounts.UserNotifier"
+        assert file =~ "def deliver_confirmation_instructions(user, url)"
+      end)
+    end)
+  end
+end

--- a/test/mix_helper.exs
+++ b/test/mix_helper.exs
@@ -1,0 +1,150 @@
+# Get Mix output sent to the current
+# process to avoid polluting tests.
+Mix.shell(Mix.Shell.Process)
+
+# Mock live reloading for testing the generated application.
+defmodule Phoenix.LiveReloader do
+  def init(opts), do: opts
+  def call(conn, _), do: conn
+end
+
+defmodule MixHelper do
+  import ExUnit.Assertions
+  import ExUnit.CaptureIO
+
+  def tmp_path do
+    Path.expand("../../tmp", __DIR__)
+  end
+
+  defp random_string(len) do
+    len |> :crypto.strong_rand_bytes() |> Base.encode64() |> binary_part(0, len)
+  end
+
+  def in_tmp(which, function) do
+    path = Path.join([tmp_path(), random_string(10), to_string(which)])
+
+    try do
+      File.rm_rf!(path)
+      File.mkdir_p!(path)
+      File.cd!(path, function)
+    after
+      File.rm_rf!(path)
+    end
+  end
+
+  def in_tmp_project(which, function) do
+    conf_before = Application.get_env(:phoenix, :generators) || []
+    path = Path.join([tmp_path(), random_string(10), to_string(which)])
+
+    try do
+      File.rm_rf!(path)
+      File.mkdir_p!(path)
+
+      File.cd!(path, fn ->
+        File.touch!("mix.exs")
+        function.()
+      end)
+    after
+      File.rm_rf!(path)
+      Application.put_env(:phoenix, :generators, conf_before)
+    end
+  end
+
+  def in_tmp_umbrella_project(which, function) do
+    conf_before = Application.get_env(:phoenix, :generators) || []
+    path = Path.join([tmp_path(), random_string(10), to_string(which)])
+
+    try do
+      apps_path = Path.join(path, "apps")
+      config_path = Path.join(path, "config")
+      File.rm_rf!(path)
+      File.mkdir_p!(path)
+      File.mkdir_p!(apps_path)
+      File.mkdir_p!(config_path)
+      File.touch!(Path.join(path, "mix.exs"))
+
+      for file <- ~w(config.exs dev.exs test.exs prod.exs prod.secret.exs) do
+        File.write!(Path.join(config_path, file), "use Mix.Config\n")
+      end
+
+      File.cd!(apps_path, function)
+    after
+      Application.put_env(:phoenix, :generators, conf_before)
+      File.rm_rf!(path)
+    end
+  end
+
+  def in_project(app, path, fun) do
+    %{name: name, file: file} = Mix.Project.pop()
+
+    try do
+      capture_io(:stderr, fn ->
+        Mix.Project.in_project(app, path, [], fun)
+      end)
+    after
+      Mix.Project.push(name, file)
+    end
+  end
+
+  def assert_file(file) do
+    assert File.regular?(file), "Expected #{file} to exist, but does not"
+  end
+
+  def refute_file(file) do
+    refute File.regular?(file), "Expected #{file} to not exist, but it does"
+  end
+
+  def assert_file(file, match) do
+    cond do
+      is_list(match) ->
+        assert_file(file, &Enum.each(match, fn m -> assert &1 =~ m end))
+
+      is_binary(match) or Regex.regex?(match) ->
+        assert_file(file, &assert(&1 =~ match))
+
+      is_function(match, 1) ->
+        assert_file(file)
+        match.(File.read!(file))
+
+      true ->
+        raise inspect({file, match})
+    end
+  end
+
+  def with_generator_env(new_env, fun) do
+    Application.put_env(:phoenix, :generators, new_env)
+
+    try do
+      fun.()
+    after
+      Application.delete_env(:phoenix, :generators)
+    end
+  end
+
+  def umbrella_mixfile_contents do
+    """
+    defmodule Umbrella.MixProject do
+      use Mix.Project
+
+      def project do
+        [
+          apps_path: "apps",
+          deps: deps()
+        ]
+      end
+
+      defp deps do
+        []
+      end
+    end
+    """
+  end
+
+  def flush do
+    receive do
+      _ -> flush()
+    after
+      0 -> :ok
+    end
+  end
+end


### PR DESCRIPTION
This adds the basic scaffolding for `Mix.Tasks.Phx.Gen.Auth` and generates the `<Schema>Notifier` module.

The original module is here: https://github.com/dashbitco/mix_phx_gen_auth_demo/pull/1/files#diff-207bcaccba470cef223a589c0a45d2fe

### Other notes

1. I ended up copying across `mix_helper.exs` because I wasn't sure I should be trying to do a path-based `Code.require_file` into the phoenix dependency.
2. I had to create my own `generator_paths` function because I wanted to return `[".", :phx_gen_auth]` instead of `[".", :phoenix]`. Eventually, I think this will need to return `[".", :phx_gen_auth, :phoenix]` if I start calling the phoenix context or schema generators.
3. It looks like the test project that's generated via `in_tmp_project/2` is `phx_gen_auth`. I'm not sure if there's an easy way to change that app name to something more easily understandable like  `my_app`.