### PR TITLE
Update generated code to 6637c8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        elixir: ["1.10.2", "1.9.4", "1.8.2", "1.7.4"]
+        elixir: ["1.10.2", "1.9.4", "1.8.2"]
         include:
           - elixir: "1.10.2"
             otp: "22.2.8"
@@ -24,9 +24,6 @@ jobs:
             otp: "22.2.8"
             check_formatting: true
           - elixir: "1.8.2"
-            otp: "22.2.8"
-            check_formatting: false
-          - elixir: "1.7.4"
             otp: "22.2.8"
             check_formatting: false
     steps:
@@ -85,15 +82,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        elixir: ["1.10.2", "1.9.4", "1.8.2", "1.7.4"]
+        elixir: ["1.10.2", "1.9.4", "1.8.2"]
         include:
           - elixir: "1.10.2"
             otp: "22.2.8"
           - elixir: "1.9.4"
             otp: "22.2.8"
           - elixir: "1.8.2"
-            otp: "22.2.8"
-          - elixir: "1.7.4"
             otp: "22.2.8"
     steps:
       - uses: actions/checkout@v1

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ An authentication system generator for Phoenix 1.5+ applications.
 **_Note: This project is still a work in progress and is alpha quality at the moment._**
 
 This project generates code from José Valim's [Auth PR][auth pr] and is up to date
-through commit: [4abf89](https://github.com/dashbitco/mix_phx_gen_auth_demo/pull/1/commits/4abf899e35adc5d6157d1169309d9a474893061e).
+through commit: [6637c8](https://github.com/dashbitco/mix_phx_gen_auth_demo/pull/1/commits/6637c85d30adb77f4f2f3088f7f9753d1827c99c).
 
 ## Overview
 

--- a/lib/mix/tasks/phx.gen.auth.ex
+++ b/lib/mix/tasks/phx.gen.auth.ex
@@ -139,6 +139,7 @@ defmodule Mix.Tasks.Phx.Gen.Auth do
       migration: migration,
       endpoint_module: Module.concat([context.web_module, Endpoint]),
       auth_module: Module.concat([context.web_module, schema.web_namespace, "#{inspect(schema.alias)}Auth"]),
+      requires_inspect_impls?: Version.compare(System.version(), "1.8.0") == :lt,
       router_scope: router_scope(context),
       web_path_prefix: web_path_prefix(schema),
       test_case_options: test_case_options(ecto_adapter)

--- a/lib/mix/tasks/phx.gen.auth.ex
+++ b/lib/mix/tasks/phx.gen.auth.ex
@@ -139,7 +139,6 @@ defmodule Mix.Tasks.Phx.Gen.Auth do
       migration: migration,
       endpoint_module: Module.concat([context.web_module, Endpoint]),
       auth_module: Module.concat([context.web_module, schema.web_namespace, "#{inspect(schema.alias)}Auth"]),
-      requires_inspect_impls?: Version.compare(System.version(), "1.8.0") == :lt,
       router_scope: router_scope(context),
       web_path_prefix: web_path_prefix(schema),
       test_case_options: test_case_options(ecto_adapter)

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule Phx.Gen.Auth.MixProject do
     [
       app: :phx_gen_auth,
       version: "0.1.0",
-      elixir: "~> 1.7",
+      elixir: "~> 1.8",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       preferred_cli_env: [docs: :docs],

--- a/priv/templates/phx.gen.auth/migration.ex
+++ b/priv/templates/phx.gen.auth/migration.ex
@@ -18,7 +18,7 @@ defmodule <%= inspect schema.repo %>.Migrations.Create<%= inspect schema.alias %
       <%= migration.column_definitions[:token] %>
       add :context, :string, null: false
       add :sent_to, :string
-      add :inserted_at, :naive_datetime
+      timestamps(updated_at: false)
     end
 
     create unique_index(:<%= schema.singular %>_tokens, [:context, :token])

--- a/priv/templates/phx.gen.auth/schema.ex
+++ b/priv/templates/phx.gen.auth/schema.ex
@@ -2,7 +2,19 @@ defmodule <%= inspect schema.module %> do
   use Ecto.Schema
   import Ecto.Changeset
 
-  # TODO: support binary ids
+  <%= if requires_inspect_impls? do %>##
+  # Deriving the Inspect protocol is only supported in Elixir 1.8+.
+  #
+  # In order to protect against accidentally leaking passwords, a custom
+  # `Inspect` impl has been added to the bottom of this module.
+  #
+  # After upgrading to Elixir 1.8+, the if statement around @derive
+  # and the inspect impl at the bottom of this module can be removed
+  ##
+  if Version.compare(System.version(), "1.8.0") in [:eq, :gt] do
+    @derive {Inspect, except: [:password]}
+  end
+  <% else %>@derive {Inspect, except: [:password]}<% end %>
   schema <%= inspect schema.table %> do
     field :email, :string
     field :password, :string, virtual: true
@@ -16,9 +28,9 @@ defmodule <%= inspect schema.module %> do
   A <%= schema.singular %> changeset for registration.
 
   It is important to validate the length of both e-mail and password.
-  Otherwise databases may truncate them without warnings, which could
-  lead to unpredictable or insecure behaviour. Long passwords may also
-  be very expensive to hash.
+  Otherwise databases may truncate the e-mail without warnings, which
+  could lead to unpredictable or insecure behaviour. Long passwords may
+  also be very expensive to for certain algorithms.
   """
   def registration_changeset(<%= schema.singular %>, attrs) do
     <%= schema.singular %>
@@ -50,7 +62,9 @@ defmodule <%= inspect schema.module %> do
     password = get_change(changeset, :password)
 
     if password && changeset.valid? do
-      put_change(changeset, :hashed_password, Bcrypt.hash_pwd_salt(password))
+      changeset
+      |> put_change(:hashed_password, Bcrypt.hash_pwd_salt(password))
+      |> delete_change(:password)
     else
       changeset
     end
@@ -116,5 +130,46 @@ defmodule <%= inspect schema.module %> do
     else
       add_error(changeset, :current_password, "is not valid")
     end
-  end
+  end<%= if requires_inspect_impls? do %>
+
+  ###
+  # This `Inspect` implementation is only needed for Elixir versions < 1.8
+  # and prevents `inspect/2` from returning sensitive fields.
+  #
+  # This can be removed after upgrading to Elixir 1.8+ and sensitive
+  # fields can be controlled with the the following line at the top of this
+  # module.
+  #
+  #     @derive {Inspect, except: [:password]}
+  ###
+  if Version.compare(System.version(), "1.8.0") == :lt do
+    defimpl Inspect do
+      @fields_to_exclude [:password]
+
+      import Inspect.Algebra
+
+      def inspect(<%= schema.singular %>, opts) do
+        colorless_opts = %{opts | syntax_colors: []}
+        name = Inspect.Atom.inspect(@for, colorless_opts)
+
+        open = color("#" <> name <> "<", :map, opts)
+        sep = color(",", :map, opts)
+        close = color(">", :map, opts)
+
+        map = Map.drop(<%= schema.singular %>, @fields_to_exclude ++ [:__struct__, :__exception__])
+
+        # Use the :limit option and an extra element to force
+        # `container_doc/6` to append "...".
+        opts = %{opts | limit: min(opts.limit, map_size(map))}
+
+        field_list =
+          map
+          |> Map.to_list()
+          |> Kernel.++(["..."])
+
+        container_doc(open, field_list, close, opts, &Inspect.List.keyword/2, separator: sep, break: :strict)
+
+      end
+    end
+  end<% end %>
 end

--- a/priv/templates/phx.gen.auth/schema.ex
+++ b/priv/templates/phx.gen.auth/schema.ex
@@ -2,19 +2,7 @@ defmodule <%= inspect schema.module %> do
   use Ecto.Schema
   import Ecto.Changeset
 
-  <%= if requires_inspect_impls? do %>##
-  # Deriving the Inspect protocol is only supported in Elixir 1.8+.
-  #
-  # In order to protect against accidentally leaking passwords, a custom
-  # `Inspect` impl has been added to the bottom of this module.
-  #
-  # After upgrading to Elixir 1.8+, the if statement around @derive
-  # and the inspect impl at the bottom of this module can be removed
-  ##
-  if Version.compare(System.version(), "1.8.0") in [:eq, :gt] do
-    @derive {Inspect, except: [:password]}
-  end
-  <% else %>@derive {Inspect, except: [:password]}<% end %>
+  @derive {Inspect, except: [:password]}
   schema <%= inspect schema.table %> do
     field :email, :string
     field :password, :string, virtual: true
@@ -130,46 +118,5 @@ defmodule <%= inspect schema.module %> do
     else
       add_error(changeset, :current_password, "is not valid")
     end
-  end<%= if requires_inspect_impls? do %>
-
-  ###
-  # This `Inspect` implementation is only needed for Elixir versions < 1.8
-  # and prevents `inspect/2` from returning sensitive fields.
-  #
-  # This can be removed after upgrading to Elixir 1.8+ and sensitive
-  # fields can be controlled with the the following line at the top of this
-  # module.
-  #
-  #     @derive {Inspect, except: [:password]}
-  ###
-  if Version.compare(System.version(), "1.8.0") == :lt do
-    defimpl Inspect do
-      @fields_to_exclude [:password]
-
-      import Inspect.Algebra
-
-      def inspect(<%= schema.singular %>, opts) do
-        colorless_opts = %{opts | syntax_colors: []}
-        name = Inspect.Atom.inspect(@for, colorless_opts)
-
-        open = color("#" <> name <> "<", :map, opts)
-        sep = color(",", :map, opts)
-        close = color(">", :map, opts)
-
-        map = Map.drop(<%= schema.singular %>, @fields_to_exclude ++ [:__struct__, :__exception__])
-
-        # Use the :limit option and an extra element to force
-        # `container_doc/6` to append "...".
-        opts = %{opts | limit: min(opts.limit, map_size(map))}
-
-        field_list =
-          map
-          |> Map.to_list()
-          |> Kernel.++(["..."])
-
-        container_doc(open, field_list, close, opts, &Inspect.List.keyword/2, separator: sep, break: :strict)
-
-      end
-    end
-  end<% end %>
+  end
 end

--- a/priv/templates/phx.gen.auth/settings_edit.html.eex
+++ b/priv/templates/phx.gen.auth/settings_edit.html.eex
@@ -14,7 +14,7 @@
   <%%= error_tag f, :email %>
 
   <%%= label f, :current_password %>
-  <%%= password_input f, :current_password, required: true, name: "current_password" %>
+  <%%= password_input f, :current_password, required: true, name: "current_password", id: "current_password_for_email" %>
   <%%= error_tag f, :current_password %>
 
   <div>
@@ -40,7 +40,7 @@
   <%%= error_tag f, :password_confirmation %>
 
   <%%= label f, :current_password %>
-  <%%= password_input f, :current_password, required: true, name: "current_password" %>
+  <%%= password_input f, :current_password, required: true, name: "current_password", id: "current_password_for_password" %>
   <%%= error_tag f, :current_password %>
 
   <div>

--- a/priv/templates/phx.gen.auth/test_cases.exs
+++ b/priv/templates/phx.gen.auth/test_cases.exs
@@ -86,6 +86,7 @@
       assert <%= schema.singular %>.email == email
       assert is_binary(<%= schema.singular %>.hashed_password)
       assert is_nil(<%= schema.singular %>.confirmed_at)
+      assert is_nil(<%= schema.singular %>.password)
     end
   end
 
@@ -257,11 +258,12 @@
     end
 
     test "updates the password", %{<%= schema.singular %>: <%= schema.singular %>} do
-      {:ok, _} =
+      {:ok, <%= schema.singular %>} =
         <%= inspect context.alias %>.update_<%= schema.singular %>_password(<%= schema.singular %>, valid_<%= schema.singular %>_password(), %{
           password: "new valid password"
         })
 
+      assert is_nil(<%= schema.singular %>.password)
       assert <%= inspect context.alias %>.get_<%= schema.singular %>_by_email_and_password(<%= schema.singular %>.email, "new valid password")
     end
 
@@ -325,7 +327,7 @@
       <%= schema.singular %> = <%= schema.singular %>_fixture()
       token = <%= inspect context.alias %>.generate_session_token(<%= schema.singular %>)
       assert <%= inspect context.alias %>.delete_session_token(token) == :ok
-      refute <%= inspect context.alias %>.get_<%= schema.singular %>_by_session_token("oops")
+      refute <%= inspect context.alias %>.get_<%= schema.singular %>_by_session_token(token)
     end
   end
 
@@ -455,7 +457,8 @@
     end
 
     test "updates the password", %{<%= schema.singular %>: <%= schema.singular %>} do
-      {:ok, _} = <%= inspect context.alias %>.reset_<%= schema.singular %>_password(<%= schema.singular %>, %{password: "new valid password"})
+      {:ok, updated_<%= schema.singular %>} = <%= inspect context.alias %>.reset_<%= schema.singular %>_password(<%= schema.singular %>, %{password: "new valid password"})
+      assert is_nil(updated_<%= schema.singular %>.password)
       assert <%= inspect context.alias %>.get_<%= schema.singular %>_by_email_and_password(<%= schema.singular %>.email, "new valid password")
     end
 
@@ -463,5 +466,11 @@
       _ = <%= inspect context.alias %>.generate_session_token(<%= schema.singular %>)
       {:ok, _} = <%= inspect context.alias %>.reset_<%= schema.singular %>_password(<%= schema.singular %>, %{password: "new valid password"})
       refute Repo.get_by(<%= inspect schema.alias %>Token, <%= schema.singular %>_id: <%= schema.singular %>.id)
+    end
+  end
+
+  describe "inspect/2" do
+    test "does not include password" do
+      refute inspect(%<%= inspect schema.alias %>{password: "123456"}) =~ "password: \"123456\""
     end
   end

--- a/test/support/integration_test_helpers.ex
+++ b/test/support/integration_test_helpers.ex
@@ -66,7 +66,7 @@ defmodule Phx.Gen.Auth.TestSupport.IntegrationTestHelpers do
   end
 
   def mix_deps_get_and_compile(app_path) do
-    mix_run!(["do", "deps.get", "--no-archives-check,", "deps.compile"], cd: app_path)
+    mix_run!(["do", "deps.get", "--no-archives-check,", "compile"], cd: app_path)
   end
 
   def mix_run!(args, opts \\ []) when is_list(args) and is_list(opts) do
@@ -99,7 +99,7 @@ defmodule Phx.Gen.Auth.TestSupport.IntegrationTestHelpers do
   end
 
   def assert_no_compilation_warnings(app_path) do
-    mix_run!(~w(compile --warnings-as-errors), cd: app_path)
+    mix_run!(~w(compile --force --warnings-as-errors), cd: app_path)
   end
 
   def assert_file(file) do


### PR DESCRIPTION
Updating generated code to this commit: https://github.com/dashbitco/mix_phx_gen_auth_demo/pull/1/commits/6637c85d30adb77f4f2f3088f7f9753d1827c99c

Changes to `mix_deps_get_and_compile/0` are to fix the following error

    1) test inspect/2 does not include password (RainyDay.AccountsTest)
      apps/rainy_day/test/rainy_day/accounts_test.exs:477
      Refute with =~ failed
      code:  refute inspect(%User{password: "123456"}) =~ "password: \"123456\""
      left:  "%RainyDay.Accounts.User{__meta__: #Ecto.Schema.Metadata<:built, \"users\">, confirmed_at: nil, email: nil, hashed_password: nil, id: nil, inserted_at: nil, password: \"123456\", updated_at: nil}"
      right: "password: \"123456\""
      stacktrace:
        test/rainy_day/accounts_test.exs:478: (test)

I think the problem was the Inspect protocol was compiled for the dependencies, but not recompiled with the updated application code. By running `mix compile` instead of `mix deps.compile` it seems to correctly recompile the inspect protocol so the tests pass.

Finally, since Elixir < 1.8, does not support deriving the `Inspect` protocol (with the `:except` option), this conditionally adds a custom `Inspect` implementation when the project is generated on Elixir 1.7.