### PR TITLE
Add support for switching password hashing libraries

### DIFF
--- a/lib/mix/phx_gen_auth/hashing_library.ex
+++ b/lib/mix/phx_gen_auth/hashing_library.ex
@@ -1,0 +1,47 @@
+defmodule Mix.Phx.Gen.Auth.HashingLibrary do
+  @moduledoc false
+
+  defstruct [:module, :mix_dependency, :test_config]
+
+  def build("bcrypt") do
+    lib = %__MODULE__{
+      module: Bcrypt,
+      mix_dependency: ~s|{:bcrypt_elixir, "~> 2.0\"}|,
+      test_config: """
+      config :bcrypt_elixir, :log_rounds, 1
+      """
+    }
+
+    {:ok, lib}
+  end
+
+  def build("pbkdf2") do
+    lib = %__MODULE__{
+      module: Pbkdf2,
+      mix_dependency: ~s|{:pbkdf2_elixir, "~> 1.0\"}|,
+      test_config: """
+      config :pbkdf2_elixir, :rounds, 1
+      """
+    }
+
+    {:ok, lib}
+  end
+
+  def build("argon2") do
+    lib = %__MODULE__{
+      module: Argon2,
+      mix_dependency: ~s|{:argon2_elixir, "~> 2.0\"}|,
+      test_config: """
+      config :argon2_elixir,
+        t_cost: 1,
+        m_cost: 8
+      """
+    }
+
+    {:ok, lib}
+  end
+
+  def build(other) do
+    {:error, {:unknown_library, other}}
+  end
+end

--- a/priv/templates/phx.gen.auth/schema.ex
+++ b/priv/templates/phx.gen.auth/schema.ex
@@ -53,7 +53,7 @@ defmodule <%= inspect schema.module %> do
 
     if password && changeset.valid? do
       changeset
-      |> put_change(:hashed_password, Bcrypt.hash_pwd_salt(password))
+      |> put_change(:hashed_password, <%= inspect hashing_library.module %>.hash_pwd_salt(password))
       |> delete_change(:password)
     else
       changeset
@@ -103,11 +103,11 @@ defmodule <%= inspect schema.module %> do
   """
   def valid_password?(%<%= inspect schema.module %>{hashed_password: hashed_password}, password)
       when is_binary(hashed_password) and byte_size(password) > 0 do
-    Bcrypt.verify_pass(password, hashed_password)
+    <%= inspect hashing_library.module %>.verify_pass(password, hashed_password)
   end
 
   def valid_password?(_, _) do
-    Bcrypt.hash_pwd_salt("unused hash to avoid timing attacks")
+    <%= inspect hashing_library.module %>.hash_pwd_salt("unused hash to avoid timing attacks")
     false
   end
 

--- a/test/mix/tasks/phx.gen.auth_test.exs
+++ b/test/mix/tasks/phx.gen.auth_test.exs
@@ -48,6 +48,10 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
       assert_raise OptionParser.ParseError, ~r/unknown option/i, fn ->
         Gen.Auth.run(~w(Accounts User users --no-schema))
       end
+
+      assert_raise Mix.Error, ~r/Unknown value for --hashing-lib/, fn ->
+        Gen.Auth.run(~w(Accounts User users --hashing-lib unknown))
+      end
     end)
   end
 end


### PR DESCRIPTION
This adds a new option (`--hashing-lib`) to support multiple password hashing libraries. Per the documentation, on linux it defaults to `bcrypt` and on windows it defaults to `pbkdf2`. It also adds support for `argon2` and refers users to the ComeOnIn github page to choose a library.

Closes #3 