### PR TITLE
Generate tokens table from --table option

### DIFF
--- a/lib/mix/tasks/phx.gen.auth.ex
+++ b/lib/mix/tasks/phx.gen.auth.ex
@@ -6,6 +6,9 @@ defmodule Mix.Tasks.Phx.Gen.Auth do
 
       mix phx.gen.auth Accounts User users
 
+  The first argument is the context module followed by the schema module
+  and its plural name (used as the schema table name).
+
   ## Web namespace
 
   By default, the controllers and view will be namespaced by the schema name.
@@ -23,6 +26,16 @@ defmodule Mix.Tasks.Phx.Gen.Auth do
   * `test/my_app_web/controllers/warehouse/user_auth_test.exs`
   * `test/my_app_web/controllers/warehouse/user_confirmation_controller_test.exs`
   * and so on...
+
+  ## Custom table names
+
+  By default, the table name for the migration and schema will be
+  the plural name provided for the resource. To customize this value,
+  a `--table` option may be provided. For example:
+
+      mix phx.gen.auth Accounts User users --table accounts_users
+
+  This will cause the generated tables to be named `"accounts_users"` and `"accounts_users_tokens"`.
 
   ## Notes about the generated authentication system
 
@@ -133,7 +146,7 @@ defmodule Mix.Tasks.Phx.Gen.Auth do
   alias Mix.Tasks.Phx.Gen
   alias Mix.Phx.Gen.Auth.{HashingLibrary, Injector, Migration}
 
-  @switches [web: :string, binary_id: :boolean, hashing_lib: :string]
+  @switches [web: :string, binary_id: :boolean, hashing_lib: :string, table: :string]
 
   @doc false
   def run(args) do
@@ -237,7 +250,7 @@ defmodule Mix.Tasks.Phx.Gen.Auth do
 
     [
       {:eex, "context_fixtures.ex", Path.join([context_app_prefix, "test", "support", "fixtures", "#{context.basename}_fixtures.ex"])},
-      {:eex, "migration.ex", Path.join([migrations_prefix, "#{timestamp()}_create_#{schema.singular}_auth_tables.exs"])},
+      {:eex, "migration.ex", Path.join([migrations_prefix, "#{timestamp()}_create_#{schema.table}_auth_tables.exs"])},
       {:eex, "notifier.ex", Path.join([context.dir, "#{schema.singular}_notifier.ex"])},
       {:eex, "schema.ex", Path.join([context.dir, "#{schema.singular}.ex"])},
       {:eex, "schema_token.ex", Path.join([context.dir, "#{schema.singular}_token.ex"])},

--- a/priv/templates/phx.gen.auth/migration.ex
+++ b/priv/templates/phx.gen.auth/migration.ex
@@ -1,4 +1,4 @@
-defmodule <%= inspect schema.repo %>.Migrations.Create<%= inspect schema.alias %>AuthTables do
+defmodule <%= inspect schema.repo %>.Migrations.Create<%= Macro.camelize(schema.table) %>AuthTables do
   use Ecto.Migration
 
   def change do<%= if Enum.any?(migration.extensions) do %><%= for extension <- migration.extensions do %>
@@ -14,7 +14,7 @@ defmodule <%= inspect schema.repo %>.Migrations.Create<%= inspect schema.alias %
 
     create unique_index(:<%= schema.table %>, [:email])
 
-    create table(:<%= schema.singular %>_tokens<%= if schema.binary_id do %>, primary_key: false<% end %>) do
+    create table(:<%= schema.table %>_tokens<%= if schema.binary_id do %>, primary_key: false<% end %>) do
 <%= if schema.binary_id do %>      add :id, :binary_id, primary_key: true
 <% end %>      add :<%= schema.singular %>_id, references(:<%= schema.table %>, <%= if schema.binary_id do %>type: :binary_id, <% end %>on_delete: :delete_all), null: false
       <%= migration.column_definitions[:token] %>
@@ -23,6 +23,6 @@ defmodule <%= inspect schema.repo %>.Migrations.Create<%= inspect schema.alias %
       timestamps(updated_at: false)
     end
 
-    create unique_index(:<%= schema.singular %>_tokens, [:context, :token])
+    create unique_index(:<%= schema.table %>_tokens, [:context, :token])
   end
 end

--- a/priv/templates/phx.gen.auth/schema_token.ex
+++ b/priv/templates/phx.gen.auth/schema_token.ex
@@ -14,7 +14,7 @@ defmodule <%= inspect schema.module %>Token do
 <%= if schema.binary_id do %>
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id<% end %>
-  schema "<%= schema.singular %>_tokens" do
+  schema "<%= schema.table %>_tokens" do
     field :token, :binary
     field :context, :string
     field :sent_to, :string

--- a/test/mix/tasks/phx_gen_auth/integration_tests/default_app_test.exs
+++ b/test/mix/tasks/phx_gen_auth/integration_tests/default_app_test.exs
@@ -71,12 +71,12 @@ defmodule Phx.Gen.Auth.IntegrationTests.DefaultAppTest do
 
     [migration] =
       test_app_path
-      |> Path.join("priv/repo/migrations/*_create_user_auth_tables.exs")
+      |> Path.join("priv/repo/migrations/*_create_users_auth_tables.exs")
       |> Path.wildcard()
 
     assert_file(migration, fn file ->
       assert file =~ "create table(:users)"
-      assert file =~ "create table(:user_tokens)"
+      assert file =~ "create table(:users_tokens)"
       refute file =~ "add :id, :binary_id, primary_key: true"
     end)
 
@@ -144,12 +144,12 @@ defmodule Phx.Gen.Auth.IntegrationTests.DefaultAppTest do
 
     [migration] =
       test_app_path
-      |> Path.join("priv/repo/migrations/*_create_user_auth_tables.exs")
+      |> Path.join("priv/repo/migrations/*_create_users_auth_tables.exs")
       |> Path.wildcard()
 
     assert_file(migration, fn file ->
       assert file =~ "create table(:users, primary_key: false)"
-      assert file =~ "create table(:user_tokens, primary_key: false)"
+      assert file =~ "create table(:users_tokens, primary_key: false)"
       assert file =~ "add :id, :binary_id, primary_key: true"
     end)
 
@@ -189,6 +189,26 @@ defmodule Phx.Gen.Auth.IntegrationTests.DefaultAppTest do
                t_cost: 1,
                m_cost: 8
              """
+    end)
+
+    mix_deps_get_and_compile(test_app_path)
+
+    assert_no_compilation_warnings(test_app_path)
+    assert_mix_test_succeeds(test_app_path)
+  end
+
+  test "with a custom table_name", %{test_app_path: test_app_path} do
+    mix_run!(~w(phx.gen.auth Ticketing User users --table ticketing_users), cd: test_app_path)
+
+    [migration] =
+      test_app_path
+      |> Path.join("priv/repo/migrations/*_create_ticketing_users_auth_tables.exs")
+      |> Path.wildcard()
+
+    assert_file(migration, fn file ->
+      assert file =~ "defmodule Demo.Repo.Migrations.CreateTicketingUsersAuthTables do"
+      assert file =~ "create table(:ticketing_users)"
+      assert file =~ "create table(:ticketing_users_tokens)"
     end)
 
     mix_deps_get_and_compile(test_app_path)

--- a/test/mix/tasks/phx_gen_auth/integration_tests/postgres_binary_id_app_test.exs
+++ b/test/mix/tasks/phx_gen_auth/integration_tests/postgres_binary_id_app_test.exs
@@ -18,12 +18,12 @@ defmodule Phx.Gen.Auth.IntegrationTests.PostgresBinaryIdAppTest do
 
     [migration] =
       test_app_path
-      |> Path.join("priv/repo/migrations/*_create_user_auth_tables.exs")
+      |> Path.join("priv/repo/migrations/*_create_users_auth_tables.exs")
       |> Path.wildcard()
 
     assert_file(migration, fn file ->
       assert file =~ "create table(:users, primary_key: false)"
-      assert file =~ "create table(:user_tokens, primary_key: false)"
+      assert file =~ "create table(:users_tokens, primary_key: false)"
       assert file =~ "add :id, :binary_id, primary_key: true"
     end)
 


### PR DESCRIPTION
When running this command

```
mix phx.gen.auth Ticketing User users --table ticketing_users
```
it currently generates `ticketing_users` and `user_tokens` tables. This becomes an issue when the user also runs
```
mix phx.gen.auth BackOffice User users --table back_office_users
```
and it generates `back_office_users` and `user_tokens` (duplicate) table.

This PR now generates the tokens table name by using the users table and appending `_tokens`. This differs from the [original PR](https://github.com/dashbitco/mix_phx_gen_auth_demo/pull/1/files#diff-6180415297fceba8d5f78cff52763085) because it generates `ticketing_users_tokens` instead of `ticketing_user_tokens`, but it seems like the easiest approach without trying to take the value of the `--table` option and make it singular.


Fixes #5.

@josevalim, Does this seem like an acceptable solution?

