### PR TITLE
Update document for mix test

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,23 @@ expected.
 
     $ mix test
 
+You need to add following code in the `test/support/conn_case.ex` if upgraded from Phoenix 1.4:
+
+```diff
+using do
+  quote do
+    # Import conveniences for testing with connections
+    import Plug.Conn
+    import Phoenix.ConnTest
++   import DemoWeb.ConnCase
+    alias DemoWeb.Router.Helpers, as: Routes
+
+    # The default endpoint for testing
+    @endpoint DemoWeb.Endpoint
+  end
+end
+```
+
 Finally, let's start the our phoenix server and try it out.
 
     $ mix phx.server


### PR DESCRIPTION
In case the application is upgraded from Phoenix 1.4.

The test will fail without this line:
```
== Compilation error in file test/brightu_web/controllers/user_session_controller_test.exs ==
** (CompileError) test/brightu_web/controllers/user_session_controller_test.exs:2: unsupported option :login_user given to import
    (brightu_web 0.1.0) expanding macro: BrightuWeb.ConnCase.__using__/1
    test/brightu_web/controllers/user_session_controller_test.exs:2: BrightuWeb.UserSessionControllerTest (module)
    (elixir 1.10.2) expanding macro: Kernel.use/2
    test/brightu_web/controllers/user_session_controller_test.exs:2: BrightuWeb.UserSessionControllerTest (module)
    (elixir 1.10.2) lib/kernel/parallel_compiler.ex:396: Kernel.ParallelCompiler.require_file/2
    (elixir 1.10.2) lib/kernel/parallel_compiler.ex:306: anonymous fn/4 in Kernel.ParallelCompiler.spawn_workers/7
```
