### PR TITLE
Remove unused if

### DIFF
--- a/priv/templates/phx.gen.auth/schema.ex
+++ b/priv/templates/phx.gen.auth/schema.ex
@@ -45,17 +45,15 @@ defmodule <%= inspect schema.module %> do
     # |> validate_format(:password, ~r/[a-z]/, message: "at least one lower case character")
     # |> validate_format(:password, ~r/[A-Z]/, message: "at least one upper case character")
     # |> validate_format(:password, ~r/[!?@#$%^&*_0-9]/, message: "at least one digit or punctuation character")
-    |> prepare_changes(&maybe_hash_password/1)
+    |> prepare_changes(&hash_password/1)
   end
 
-  defp maybe_hash_password(changeset) do
-    if password = get_change(changeset, :password) do
-      changeset
-      |> put_change(:hashed_password, <%= inspect hashing_library.module %>.hash_pwd_salt(password))
-      |> delete_change(:password)
-    else
-      changeset
-    end
+  defp hash_password(changeset) do
+    password = get_change(changeset, :password)
+
+    changeset
+    |> put_change(:hashed_password, <%= inspect hashing_library.module %>.hash_pwd_salt(password))
+    |> delete_change(:password)
   end
 
   @doc """


### PR DESCRIPTION
Issue #14 

Remove unused `if`.

We are requiring the `password` field before, so we don't need to check if the changeset has it or no, it will be always present.