### PR TITLE
Change incorrect login/logout nouns to "log in"/"log out" verbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Updated generated code be up to date through commit: [4664c3](https://github.com/dashbitco/mix_phx_gen_auth_demo/pull/1/commits/4664c376273af7100e31766ccf2d76bc7cf153e4). [[Diff](https://github.com/dashbitco/mix_phx_gen_auth_demo/compare/6ae63a...4664c3)]
 * Upgraded phoenix requirement to `~> 1.5.2` to use undeprecated `MyApp.Endpoint.subscribe/1` function.
 * Updated generator to be compatible with existing fixtures modules.
-* Set `live_socket_id` on login and disconnect on logout.
+* Set `live_socket_id` on log in and disconnect on logout.
 * Updated logout to succeed even if user is already logged out.
 * Added index on user_tokens.user_id column
 * Renamed several functions (see diff).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@
 * Updated generated code be up to date through commit: [4664c3](https://github.com/dashbitco/mix_phx_gen_auth_demo/pull/1/commits/4664c376273af7100e31766ccf2d76bc7cf153e4). [[Diff](https://github.com/dashbitco/mix_phx_gen_auth_demo/compare/6ae63a...4664c3)]
 * Upgraded phoenix requirement to `~> 1.5.2` to use undeprecated `MyApp.Endpoint.subscribe/1` function.
 * Updated generator to be compatible with existing fixtures modules.
-* Set `live_socket_id` on log in and disconnect on logout.
-* Updated logout to succeed even if user is already logged out.
+* Set `live_socket_id` on log in and disconnect on log out.
+* Updated log out to succeed even if user is already logged out.
 * Added index on user_tokens.user_id column
 * Renamed several functions (see diff).
 

--- a/guides/overview.md
+++ b/guides/overview.md
@@ -56,7 +56,7 @@ allows you to track how many sessions are active for each account.
 You could even expose this information to users if desired.
 
 Note that whenever the password changes (either via reset password
-or directly), all tokens are deleted and the user has to login
+or directly), all tokens are deleted and the user has to log in
 again on all devices.
 
 ## Enumeration attacks

--- a/priv/templates/phx.gen.auth/_menu.html.eex
+++ b/priv/templates/phx.gen.auth/_menu.html.eex
@@ -2,7 +2,7 @@
 <%%= if @current_<%= schema.singular %> do %>
   <li><%%= @current_<%= schema.singular %>.email %></li>
   <li><%%= link "Settings", to: Routes.<%= schema.route_helper %>_settings_path(@conn, :edit) %></li>
-  <li><%%= link "Logout", to: Routes.<%= schema.route_helper %>_session_path(@conn, :delete), method: :delete %></li>
+  <li><%%= link "Log out", to: Routes.<%= schema.route_helper %>_session_path(@conn, :delete), method: :delete %></li>
 <%% else %>
   <li><%%= link "Register", to: Routes.<%= schema.route_helper %>_registration_path(@conn, :new) %></li>
   <li><%%= link "Log in", to: Routes.<%= schema.route_helper %>_session_path(@conn, :new) %></li>

--- a/priv/templates/phx.gen.auth/_menu.html.eex
+++ b/priv/templates/phx.gen.auth/_menu.html.eex
@@ -5,6 +5,6 @@
   <li><%%= link "Logout", to: Routes.<%= schema.route_helper %>_session_path(@conn, :delete), method: :delete %></li>
 <%% else %>
   <li><%%= link "Register", to: Routes.<%= schema.route_helper %>_registration_path(@conn, :new) %></li>
-  <li><%%= link "Login", to: Routes.<%= schema.route_helper %>_session_path(@conn, :new) %></li>
+  <li><%%= link "Log in", to: Routes.<%= schema.route_helper %>_session_path(@conn, :new) %></li>
 <%% end %>
 </ul>

--- a/priv/templates/phx.gen.auth/auth.ex
+++ b/priv/templates/phx.gen.auth/auth.ex
@@ -24,7 +24,7 @@ defmodule <%= inspect auth_module %> do
   disconnected on logout. The line can be safely removed
   if you are not using LiveView.
   """
-  def login_<%= schema.singular %>(conn, <%= schema.singular %>, params \\ %{}) do
+  def log_in_<%= schema.singular %>(conn, <%= schema.singular %>, params \\ %{}) do
     token = <%= inspect context.alias %>.generate_<%= schema.singular %>_session_token(<%= schema.singular %>)
     <%= schema.singular %>_return_to = get_session(conn, :<%= schema.singular %>_return_to)
 
@@ -46,7 +46,7 @@ defmodule <%= inspect auth_module %> do
 
   # This function renews the session ID and erases the whole
   # session to avoid fixation attacks. If there is any data
-  # in the session you may want to preserve after login/logout,
+  # in the session you may want to preserve after log in/logout,
   # you must explicitly fetch the session data before clearing
   # and then immediately set it after clearing, for example:
   #
@@ -132,7 +132,7 @@ defmodule <%= inspect auth_module %> do
       conn
     else
       conn
-      |> put_flash(:error, "You must login to access this page.")
+      |> put_flash(:error, "You must log in to access this page.")
       |> maybe_store_return_to()
       |> redirect(to: Routes.<%= schema.route_helper %>_session_path(conn, :new))
       |> halt()

--- a/priv/templates/phx.gen.auth/auth.ex
+++ b/priv/templates/phx.gen.auth/auth.ex
@@ -21,7 +21,7 @@ defmodule <%= inspect auth_module %> do
 
   It also sets a `:live_socket_id` key in the session,
   so LiveView sessions are identified and automatically
-  disconnected on logout. The line can be safely removed
+  disconnected on log out. The line can be safely removed
   if you are not using LiveView.
   """
   def log_in_<%= schema.singular %>(conn, <%= schema.singular %>, params \\ %{}) do
@@ -46,7 +46,7 @@ defmodule <%= inspect auth_module %> do
 
   # This function renews the session ID and erases the whole
   # session to avoid fixation attacks. If there is any data
-  # in the session you may want to preserve after log in/logout,
+  # in the session you may want to preserve after log in/log out,
   # you must explicitly fetch the session data before clearing
   # and then immediately set it after clearing, for example:
   #
@@ -70,7 +70,7 @@ defmodule <%= inspect auth_module %> do
 
   It clears all session data for safety. See renew_session.
   """
-  def logout_<%= schema.singular %>(conn) do
+  def log_out_<%= schema.singular %>(conn) do
     <%= schema.singular %>_token = get_session(conn, :<%= schema.singular %>_token)
     <%= schema.singular %>_token && <%= inspect context.alias %>.delete_session_token(<%= schema.singular %>_token)
 

--- a/priv/templates/phx.gen.auth/auth_test.exs
+++ b/priv/templates/phx.gen.auth/auth_test.exs
@@ -52,7 +52,7 @@ defmodule <%= inspect auth_module %>Test do
         |> put_session(:<%= schema.singular %>_token, <%= schema.singular %>_token)
         |> put_req_cookie("<%= schema.singular %>_remember_me", <%= schema.singular %>_token)
         |> fetch_cookies()
-        |> <%= inspect schema.alias %>Auth.logout_<%= schema.singular %>()
+        |> <%= inspect schema.alias %>Auth.log_out_<%= schema.singular %>()
 
       refute get_session(conn, :<%= schema.singular %>_token)
       refute conn.cookies["<%= schema.singular %>_remember_me"]
@@ -67,7 +67,7 @@ defmodule <%= inspect auth_module %>Test do
 
       conn
       |> put_session(:live_socket_id, live_socket_id)
-      |> <%= inspect(schema.alias) %>Auth.logout_<%= schema.singular %>()
+      |> <%= inspect(schema.alias) %>Auth.log_out_<%= schema.singular %>()
 
       assert_receive %Phoenix.Socket.Broadcast{
         event: "disconnect",
@@ -76,7 +76,7 @@ defmodule <%= inspect auth_module %>Test do
     end
 
     test "works even if <%= schema.singular %> is already logged out", %{conn: conn} do
-      conn = conn |> fetch_cookies() |> <%= inspect schema.alias %>Auth.logout_<%= schema.singular %>()
+      conn = conn |> fetch_cookies() |> <%= inspect schema.alias %>Auth.log_out_<%= schema.singular %>()
       refute get_session(conn, :<%= schema.singular %>_token)
       assert %{max_age: 0} = conn.resp_cookies["<%= schema.singular %>_remember_me"]
       assert redirected_to(conn) == "/"

--- a/priv/templates/phx.gen.auth/auth_test.exs
+++ b/priv/templates/phx.gen.auth/auth_test.exs
@@ -14,9 +14,9 @@ defmodule <%= inspect auth_module %>Test do
     %{<%= schema.singular %>: <%= schema.singular %>_fixture(), conn: conn}
   end
 
-  describe "login_<%= schema.singular %>/3" do
+  describe "log_in_<%= schema.singular %>/3" do
     test "stores the <%= schema.singular %> token in the session", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
-      conn = <%= inspect schema.alias %>Auth.login_<%= schema.singular %>(conn, <%= schema.singular %>)
+      conn = <%= inspect schema.alias %>Auth.log_in_<%= schema.singular %>(conn, <%= schema.singular %>)
       assert token = get_session(conn, :<%= schema.singular %>_token)
       assert get_session(conn, :live_socket_id) == "<%= schema.plural %>_sessions:#{Base.url_encode64(token)}"
       assert redirected_to(conn) == "/"
@@ -24,17 +24,17 @@ defmodule <%= inspect auth_module %>Test do
     end
 
     test "clears everything previously stored in the session", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
-      conn = conn |> put_session(:to_be_removed, "value") |> <%= inspect schema.alias %>Auth.login_<%= schema.singular %>(<%= schema.singular %>)
+      conn = conn |> put_session(:to_be_removed, "value") |> <%= inspect schema.alias %>Auth.log_in_<%= schema.singular %>(<%= schema.singular %>)
       refute get_session(conn, :to_be_removed)
     end
 
     test "redirects to the configured path", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
-      conn = conn |> put_session(:<%= schema.singular %>_return_to, "/hello") |> <%= inspect schema.alias %>Auth.login_<%= schema.singular %>(<%= schema.singular %>)
+      conn = conn |> put_session(:<%= schema.singular %>_return_to, "/hello") |> <%= inspect schema.alias %>Auth.log_in_<%= schema.singular %>(<%= schema.singular %>)
       assert redirected_to(conn) == "/hello"
     end
 
     test "writes a cookie if remember_me is configured", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
-      conn = conn |> fetch_cookies() |> <%= inspect schema.alias %>Auth.login_<%= schema.singular %>(<%= schema.singular %>, %{"remember_me" => "true"})
+      conn = conn |> fetch_cookies() |> <%= inspect schema.alias %>Auth.log_in_<%= schema.singular %>(<%= schema.singular %>, %{"remember_me" => "true"})
       assert get_session(conn, :<%= schema.singular %>_token) == conn.cookies["<%= schema.singular %>_remember_me"]
 
       assert %{value: signed_token, max_age: max_age} = conn.resp_cookies["<%= schema.singular %>_remember_me"]
@@ -92,7 +92,7 @@ defmodule <%= inspect auth_module %>Test do
 
     test "authenticates <%= schema.singular %> from cookies", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
       logged_in_conn =
-        conn |> fetch_cookies() |> <%= inspect schema.alias %>Auth.login_<%= schema.singular %>(<%= schema.singular %>, %{"remember_me" => "true"})
+        conn |> fetch_cookies() |> <%= inspect schema.alias %>Auth.log_in_<%= schema.singular %>(<%= schema.singular %>, %{"remember_me" => "true"})
 
       <%= schema.singular %>_token = logged_in_conn.cookies["<%= schema.singular %>_remember_me"]
       %{value: signed_token} = logged_in_conn.resp_cookies["<%= schema.singular %>_remember_me"]
@@ -132,8 +132,8 @@ defmodule <%= inspect auth_module %>Test do
     test "redirects if <%= schema.singular %> is not authenticated", %{conn: conn} do
       conn = conn |> fetch_flash() |> <%= inspect schema.alias %>Auth.require_authenticated_<%= schema.singular %>([])
       assert conn.halted
-      assert redirected_to(conn) == "<%= web_path_prefix %>/<%= schema.plural %>/login"
-      assert get_flash(conn, :error) == "You must login to access this page."
+      assert redirected_to(conn) == "<%= web_path_prefix %>/<%= schema.plural %>/log_in"
+      assert get_flash(conn, :error) == "You must log in to access this page."
     end
 
     test "stores the path to redirect to on GET", %{conn: conn} do

--- a/priv/templates/phx.gen.auth/confirmation_controller.ex
+++ b/priv/templates/phx.gen.auth/confirmation_controller.ex
@@ -25,7 +25,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
     |> redirect(to: "/")
   end
 
-  # Do not login the <%= schema.singular %> after confirmation to avoid a
+  # Do not log in the <%= schema.singular %> after confirmation to avoid a
   # leaked token giving the <%= schema.singular %> access to the account.
   def confirm(conn, %{"token" => token}) do
     case <%= inspect context.alias %>.confirm_<%= schema.singular %>(token) do

--- a/priv/templates/phx.gen.auth/confirmation_new.html.eex
+++ b/priv/templates/phx.gen.auth/confirmation_new.html.eex
@@ -11,5 +11,5 @@
 
 <p>
   <%%= link "Register", to: Routes.<%= schema.route_helper %>_registration_path(@conn, :new) %> |
-  <%%= link "Login", to: Routes.<%= schema.route_helper %>_session_path(@conn, :new) %>
+  <%%= link "Log in", to: Routes.<%= schema.route_helper %>_session_path(@conn, :new) %>
 </p>

--- a/priv/templates/phx.gen.auth/conn_case.exs
+++ b/priv/templates/phx.gen.auth/conn_case.exs
@@ -2,14 +2,14 @@
   @doc """
   Setup helper that registers and logs in <%= schema.plural %>.
 
-      setup :register_and_login_<%= schema.singular %>
+      setup :register_and_log_in_<%= schema.singular %>
 
   It stores an updated connection and a registered <%= schema.singular %> in the
   test context.
   """
-  def register_and_login_<%= schema.singular %>(%{conn: conn}) do
+  def register_and_log_in_<%= schema.singular %>(%{conn: conn}) do
     <%= schema.singular %> = <%= inspect context.module %>Fixtures.<%= schema.singular %>_fixture()
-    %{conn: login_<%= schema.singular %>(conn, <%= schema.singular %>), <%= schema.singular %>: <%= schema.singular %>}
+    %{conn: log_in_<%= schema.singular %>(conn, <%= schema.singular %>), <%= schema.singular %>: <%= schema.singular %>}
   end
 
   @doc """
@@ -17,7 +17,7 @@
 
   It returns an updated `conn`.
   """
-  def login_<%= schema.singular %>(conn, <%= schema.singular %>) do
+  def log_in_<%= schema.singular %>(conn, <%= schema.singular %>) do
     token = <%= inspect context.module %>.generate_<%= schema.singular %>_session_token(<%= schema.singular %>)
 
     conn

--- a/priv/templates/phx.gen.auth/registration_controller.ex
+++ b/priv/templates/phx.gen.auth/registration_controller.ex
@@ -21,7 +21,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
 
         conn
         |> put_flash(:info, "<%= schema.human_singular %> created successfully.")
-        |> <%= inspect schema.alias %>Auth.login_<%= schema.singular %>(<%= schema.singular %>)
+        |> <%= inspect schema.alias %>Auth.log_in_<%= schema.singular %>(<%= schema.singular %>)
 
       {:error, %Ecto.Changeset{} = changeset} ->
         render(conn, "new.html", changeset: changeset)

--- a/priv/templates/phx.gen.auth/registration_controller_test.exs
+++ b/priv/templates/phx.gen.auth/registration_controller_test.exs
@@ -36,7 +36,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
       response = html_response(conn, 200)
       assert response =~ email
       assert response =~ "Settings</a>"
-      assert response =~ "Logout</a>"
+      assert response =~ "Log out</a>"
     end
 
     test "render errors for invalid data", %{conn: conn} do

--- a/priv/templates/phx.gen.auth/registration_controller_test.exs
+++ b/priv/templates/phx.gen.auth/registration_controller_test.exs
@@ -8,12 +8,12 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
       conn = get(conn, Routes.<%= schema.route_helper %>_registration_path(conn, :new))
       response = html_response(conn, 200)
       assert response =~ "<h1>Register</h1>"
-      assert response =~ "Login</a>"
+      assert response =~ "Log in</a>"
       assert response =~ "Register</a>"
     end
 
     test "redirects if already logged in", %{conn: conn} do
-      conn = conn |> login_<%= schema.singular %>(<%= schema.singular %>_fixture()) |> get(Routes.<%= schema.route_helper %>_registration_path(conn, :new))
+      conn = conn |> log_in_<%= schema.singular %>(<%= schema.singular %>_fixture()) |> get(Routes.<%= schema.route_helper %>_registration_path(conn, :new))
       assert redirected_to(conn) == "/"
     end
   end

--- a/priv/templates/phx.gen.auth/registration_new.html.eex
+++ b/priv/templates/phx.gen.auth/registration_new.html.eex
@@ -21,6 +21,6 @@
 <%% end %>
 
 <p>
-  <%%= link "Login", to: Routes.<%= schema.route_helper %>_session_path(@conn, :new) %> |
+  <%%= link "Log in", to: Routes.<%= schema.route_helper %>_session_path(@conn, :new) %> |
   <%%= link "Forgot your password?", to: Routes.<%= schema.route_helper %>_reset_password_path(@conn, :new) %>
 </p>

--- a/priv/templates/phx.gen.auth/reset_password_controller.ex
+++ b/priv/templates/phx.gen.auth/reset_password_controller.ex
@@ -30,7 +30,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
     render(conn, "edit.html", changeset: <%= inspect context.alias %>.change_<%= schema.singular %>_password(conn.assigns.<%= schema.singular %>))
   end
 
-  # Do not login the <%= schema.singular %> after reset password to avoid a
+  # Do not log in the <%= schema.singular %> after reset password to avoid a
   # leaked token giving the <%= schema.singular %> access to the account.
   def update(conn, %{"<%= schema.singular %>" => <%= schema.singular %>_params}) do
     case <%= inspect context.alias %>.reset_<%= schema.singular %>_password(conn.assigns.<%= schema.singular %>, <%= schema.singular %>_params) do

--- a/priv/templates/phx.gen.auth/reset_password_controller_test.exs
+++ b/priv/templates/phx.gen.auth/reset_password_controller_test.exs
@@ -83,7 +83,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
           }
         })
 
-      assert redirected_to(conn) == "<%= web_path_prefix %>/<%= schema.plural %>/login"
+      assert redirected_to(conn) == "<%= web_path_prefix %>/<%= schema.plural %>/log_in"
       refute get_session(conn, :<%= schema.singular %>_token)
       assert get_flash(conn, :info) =~ "Password reset successfully"
       assert <%= inspect context.alias %>.get_<%= schema.singular %>_by_email_and_password(<%= schema.singular %>.email, "new valid password")

--- a/priv/templates/phx.gen.auth/reset_password_edit.html.eex
+++ b/priv/templates/phx.gen.auth/reset_password_edit.html.eex
@@ -22,5 +22,5 @@
 
 <p>
   <%%= link "Register", to: Routes.<%= schema.route_helper %>_registration_path(@conn, :new) %> |
-  <%%= link "Login", to: Routes.<%= schema.route_helper %>_session_path(@conn, :new) %>
+  <%%= link "Log in", to: Routes.<%= schema.route_helper %>_session_path(@conn, :new) %>
 </p>

--- a/priv/templates/phx.gen.auth/reset_password_new.html.eex
+++ b/priv/templates/phx.gen.auth/reset_password_new.html.eex
@@ -11,5 +11,5 @@
 
 <p>
   <%%= link "Register", to: Routes.<%= schema.route_helper %>_registration_path(@conn, :new) %> |
-  <%%= link "Login", to: Routes.<%= schema.route_helper %>_session_path(@conn, :new) %>
+  <%%= link "Log in", to: Routes.<%= schema.route_helper %>_session_path(@conn, :new) %>
 </p>

--- a/priv/templates/phx.gen.auth/routes.ex
+++ b/priv/templates/phx.gen.auth/routes.ex
@@ -6,8 +6,8 @@
 
     get "/<%= schema.plural %>/register", <%= inspect schema.alias %>RegistrationController, :new
     post "/<%= schema.plural %>/register", <%= inspect schema.alias %>RegistrationController, :create
-    get "/<%= schema.plural %>/login", <%= inspect schema.alias %>SessionController, :new
-    post "/<%= schema.plural %>/login", <%= inspect schema.alias %>SessionController, :create
+    get "/<%= schema.plural %>/log_in", <%= inspect schema.alias %>SessionController, :new
+    post "/<%= schema.plural %>/log_in", <%= inspect schema.alias %>SessionController, :create
     get "/<%= schema.plural %>/reset_password", <%= inspect schema.alias %>ResetPasswordController, :new
     post "/<%= schema.plural %>/reset_password", <%= inspect schema.alias %>ResetPasswordController, :create
     get "/<%= schema.plural %>/reset_password/:token", <%= inspect schema.alias %>ResetPasswordController, :edit

--- a/priv/templates/phx.gen.auth/routes.ex
+++ b/priv/templates/phx.gen.auth/routes.ex
@@ -26,7 +26,7 @@
   scope <%= router_scope %> do
     pipe_through [:browser]
 
-    delete "/<%= schema.plural %>/logout", <%= inspect schema.alias %>SessionController, :delete
+    delete "/<%= schema.plural %>/log_out", <%= inspect schema.alias %>SessionController, :delete
     get "/<%= schema.plural %>/confirm", <%= inspect schema.alias %>ConfirmationController, :new
     post "/<%= schema.plural %>/confirm", <%= inspect schema.alias %>ConfirmationController, :create
     get "/<%= schema.plural %>/confirm/:token", <%= inspect schema.alias %>ConfirmationController, :confirm

--- a/priv/templates/phx.gen.auth/session_controller.ex
+++ b/priv/templates/phx.gen.auth/session_controller.ex
@@ -12,7 +12,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
     %{"email" => email, "password" => password} = <%= schema.singular %>_params
 
     if <%= schema.singular %> = <%= inspect context.alias %>.get_<%= schema.singular %>_by_email_and_password(email, password) do
-      <%= inspect schema.alias %>Auth.login_<%= schema.singular %>(conn, <%= schema.singular %>, <%= schema.singular %>_params)
+      <%= inspect schema.alias %>Auth.log_in_<%= schema.singular %>(conn, <%= schema.singular %>, <%= schema.singular %>_params)
     else
       render(conn, "new.html", error_message: "Invalid e-mail or password")
     end

--- a/priv/templates/phx.gen.auth/session_controller.ex
+++ b/priv/templates/phx.gen.auth/session_controller.ex
@@ -21,6 +21,6 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
   def delete(conn, _params) do
     conn
     |> put_flash(:info, "Logged out successfully.")
-    |> <%= inspect schema.alias %>Auth.logout_<%= schema.singular %>()
+    |> <%= inspect schema.alias %>Auth.log_out_<%= schema.singular %>()
   end
 end

--- a/priv/templates/phx.gen.auth/session_controller_test.exs
+++ b/priv/templates/phx.gen.auth/session_controller_test.exs
@@ -7,22 +7,22 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
     %{<%= schema.singular %>: <%= schema.singular %>_fixture()}
   end
 
-  describe "GET <%= web_path_prefix %>/<%= schema.plural %>/login" do
-    test "renders login page", %{conn: conn} do
+  describe "GET <%= web_path_prefix %>/<%= schema.plural %>/log_in" do
+    test "renders log in page", %{conn: conn} do
       conn = get(conn, Routes.<%= schema.route_helper %>_session_path(conn, :new))
       response = html_response(conn, 200)
-      assert response =~ "<h1>Login</h1>"
-      assert response =~ "Login</a>"
+      assert response =~ "<h1>Log in</h1>"
+      assert response =~ "Log in</a>"
       assert response =~ "Register</a>"
     end
 
     test "redirects if already logged in", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
-      conn = conn |> login_<%= schema.singular %>(<%= schema.singular %>) |> get(Routes.<%= schema.route_helper %>_session_path(conn, :new))
+      conn = conn |> log_in_<%= schema.singular %>(<%= schema.singular %>) |> get(Routes.<%= schema.route_helper %>_session_path(conn, :new))
       assert redirected_to(conn) == "/"
     end
   end
 
-  describe "POST <%= web_path_prefix %>/<%= schema.plural %>/login" do
+  describe "POST <%= web_path_prefix %>/<%= schema.plural %>/log_in" do
     test "logs the <%= schema.singular %> in", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
       conn =
         post(conn, Routes.<%= schema.route_helper %>_session_path(conn, :create), %{
@@ -61,14 +61,14 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
         })
 
       response = html_response(conn, 200)
-      assert response =~ "<h1>Login</h1>"
+      assert response =~ "<h1>Log in</h1>"
       assert response =~ "Invalid e-mail or password"
     end
   end
 
   describe "DELETE <%= web_path_prefix %>/<%= schema.plural %>/logout" do
     test "logs the <%= schema.singular %> out", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
-      conn = conn |> login_<%= schema.singular %>(<%= schema.singular %>) |> delete(Routes.<%= schema.route_helper %>_session_path(conn, :delete))
+      conn = conn |> log_in_<%= schema.singular %>(<%= schema.singular %>) |> delete(Routes.<%= schema.route_helper %>_session_path(conn, :delete))
       assert redirected_to(conn) == "/"
       refute get_session(conn, :<%= schema.singular %>_token)
       assert get_flash(conn, :info) =~ "Logged out successfully"

--- a/priv/templates/phx.gen.auth/session_controller_test.exs
+++ b/priv/templates/phx.gen.auth/session_controller_test.exs
@@ -37,7 +37,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
       response = html_response(conn, 200)
       assert response =~ <%= schema.singular %>.email
       assert response =~ "Settings</a>"
-      assert response =~ "Logout</a>"
+      assert response =~ "Log out</a>"
     end
 
     test "logs the <%= schema.singular %> in with remember me", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
@@ -66,7 +66,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
     end
   end
 
-  describe "DELETE <%= web_path_prefix %>/<%= schema.plural %>/logout" do
+  describe "DELETE <%= web_path_prefix %>/<%= schema.plural %>/log_out" do
     test "logs the <%= schema.singular %> out", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
       conn = conn |> log_in_<%= schema.singular %>(<%= schema.singular %>) |> delete(Routes.<%= schema.route_helper %>_session_path(conn, :delete))
       assert redirected_to(conn) == "/"

--- a/priv/templates/phx.gen.auth/session_new.html.eex
+++ b/priv/templates/phx.gen.auth/session_new.html.eex
@@ -1,4 +1,4 @@
-<h1>Login</h1>
+<h1>Log in</h1>
 
 <%%= form_for @conn, Routes.<%= schema.route_helper %>_session_path(@conn, :create), [as: :<%= schema.singular %>], fn f -> %>
   <%%= if @error_message do %>
@@ -17,7 +17,7 @@
   <%%= checkbox f, :remember_me %>
 
   <div>
-    <%%= submit "Login" %>
+    <%%= submit "Log in" %>
   </div>
 <%% end %>
 

--- a/priv/templates/phx.gen.auth/settings_controller.ex
+++ b/priv/templates/phx.gen.auth/settings_controller.ex
@@ -55,7 +55,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
         conn
         |> put_flash(:info, "Password updated successfully.")
         |> put_session(:<%= schema.singular %>_return_to, Routes.<%= schema.route_helper %>_settings_path(conn, :edit))
-        |> <%= inspect schema.alias %>Auth.login_<%= schema.singular %>(<%= schema.singular %>)
+        |> <%= inspect schema.alias %>Auth.log_in_<%= schema.singular %>(<%= schema.singular %>)
 
       {:error, changeset} ->
         render(conn, "edit.html", password_changeset: changeset)

--- a/priv/templates/phx.gen.auth/settings_controller_test.exs
+++ b/priv/templates/phx.gen.auth/settings_controller_test.exs
@@ -4,7 +4,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
   alias <%= inspect context.module %>
   import <%= inspect context.module %>Fixtures
 
-  setup :register_and_login_<%= schema.singular %>
+  setup :register_and_log_in_<%= schema.singular %>
 
   describe "GET <%= web_path_prefix %>/<%= schema.plural %>/settings" do
     test "renders settings page", %{conn: conn} do
@@ -16,7 +16,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
     test "redirects if <%= schema.singular %> is not logged in" do
       conn = build_conn()
       conn = get(conn, Routes.<%= schema.route_helper %>_settings_path(conn, :edit))
-      assert redirected_to(conn) == "<%= web_path_prefix %>/<%= schema.plural %>/login"
+      assert redirected_to(conn) == "<%= web_path_prefix %>/<%= schema.plural %>/log_in"
     end
   end
 
@@ -119,7 +119,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
     test "redirects if <%= schema.singular %> is not logged in", %{token: token} do
       conn = build_conn()
       conn = get(conn, Routes.<%= schema.route_helper %>_settings_path(conn, :confirm_email, token))
-      assert redirected_to(conn) == "<%= web_path_prefix %>/<%= schema.plural %>/login"
+      assert redirected_to(conn) == "<%= web_path_prefix %>/<%= schema.plural %>/log_in"
     end
   end
 end

--- a/test/mix/tasks/phx_gen_auth/integration_tests/default_app_test.exs
+++ b/test/mix/tasks/phx_gen_auth/integration_tests/default_app_test.exs
@@ -66,7 +66,7 @@ defmodule Phx.Gen.Auth.IntegrationTests.DefaultAppTest do
     assert_file(Path.join(test_app_path, "test/support/fixtures/accounts_fixtures.ex"))
 
     assert_file(Path.join(test_app_path, "test/support/conn_case.ex"), fn file ->
-      assert file =~ "def login_user"
+      assert file =~ "def log_in_user"
     end)
 
     [migration] =

--- a/test/mix/tasks/phx_gen_auth/integration_tests/default_umbrella_test.exs
+++ b/test/mix/tasks/phx_gen_auth/integration_tests/default_umbrella_test.exs
@@ -22,7 +22,7 @@ defmodule Phx.Gen.Auth.IntegrationTests.DefaultUmbrellaTest do
     assert_file(Path.join(test_app_path, "apps/rainy_day/test/support/fixtures/accounts_fixtures.ex"))
 
     assert_file(Path.join(test_app_path, "apps/rainy_day_web/test/support/conn_case.ex"), fn file ->
-      assert file =~ "def login_user"
+      assert file =~ "def log_in_user"
     end)
 
     assert_no_compilation_warnings(test_app_path)


### PR DESCRIPTION
I did a search for "login" and "logout" believe I made the appropriate updates.

Fixes #32.