### PR TITLE
Changes terminology from e-mail to email to better match AP style guide.

### DIFF
--- a/guides/overview.md
+++ b/guides/overview.md
@@ -36,7 +36,7 @@ named `DemoWeb.UserAuth` with plugs such as:
 
 The generated functionality ships with an account confirmation
 mechanism, where users have to confirm their account, typically
-by e-mail. However, the generated code does not forbid users
+by email. However, the generated code does not forbid users
 from using the application if their accounts have not yet been
 confirmed. You can trivially add this functionality by customizing
 the plugs generated in the Auth module.
@@ -44,7 +44,7 @@ the plugs generated in the Auth module.
 ## Notifiers
 
 The generated code is not integrated with any system to send
-SMSs or e-mails for confirming accounts, reseting passwords,
+SMSs or emails for confirming accounts, reseting passwords,
 etc. Instead it simply logs a message to the terminal. It is
 your responsibility to integrate with the proper system after
 generation.
@@ -61,17 +61,17 @@ again on all devices.
 
 ## Enumeration attacks
 
-An enumeration attack allows an attacker to enumerate all e-mails
+An enumeration attack allows an attacker to enumerate all emails
 registered in the application. The generated authentication code
 protects against enumeration attacks on all endpoints, except in
-the registration and update e-mail forms. If your application is
+the registration and update email forms. If your application is
 really sensitive to enumeration attacks, you need to implement
 your own registration workflow, which tends to be very different
 from the workflow for most applications.
 
 ## Case sensitiveness
 
-The e-mail lookup is made to be case insensitive. Case insensitive
+The email lookup is made to be case insensitive. Case insensitive
 lookups are the default in MySQL and MSSQL but require the
 citext extension in Postgres.
 

--- a/priv/templates/phx.gen.auth/auth.ex
+++ b/priv/templates/phx.gen.auth/auth.ex
@@ -124,7 +124,7 @@ defmodule <%= inspect auth_module %> do
   @doc """
   Used for routes that require the <%= schema.singular %> to be authenticated.
 
-  If you want to enforce the <%= schema.singular %> e-mail is confirmed before
+  If you want to enforce the <%= schema.singular %> email is confirmed before
   they use the application at all, here would be a good place.
   """
   def require_authenticated_<%= schema.singular %>(conn, _opts) do

--- a/priv/templates/phx.gen.auth/confirmation_controller.ex
+++ b/priv/templates/phx.gen.auth/confirmation_controller.ex
@@ -19,8 +19,8 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
     conn
     |> put_flash(
       :info,
-      "If your e-mail is in our system and it has not been confirmed yet, " <>
-        "you will receive an e-mail with instructions shortly."
+      "If your email is in our system and it has not been confirmed yet, " <>
+        "you will receive an email with instructions shortly."
     )
     |> redirect(to: "/")
   end

--- a/priv/templates/phx.gen.auth/confirmation_controller_test.exs
+++ b/priv/templates/phx.gen.auth/confirmation_controller_test.exs
@@ -26,7 +26,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
         })
 
       assert redirected_to(conn) == "/"
-      assert get_flash(conn, :info) =~ "If your e-mail is in our system"
+      assert get_flash(conn, :info) =~ "If your email is in our system"
       assert Repo.get_by!(<%= inspect context.alias %>.<%= inspect schema.alias %>Token, <%= schema.singular %>_id: <%= schema.singular %>.id).context == "confirm"
     end
 
@@ -39,7 +39,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
         })
 
       assert redirected_to(conn) == "/"
-      assert get_flash(conn, :info) =~ "If your e-mail is in our system"
+      assert get_flash(conn, :info) =~ "If your email is in our system"
       refute Repo.get_by(<%= inspect context.alias %>.<%= inspect schema.alias %>Token, <%= schema.singular %>_id: <%= schema.singular %>.id)
     end
 
@@ -50,7 +50,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
         })
 
       assert redirected_to(conn) == "/"
-      assert get_flash(conn, :info) =~ "If your e-mail is in our system"
+      assert get_flash(conn, :info) =~ "If your email is in our system"
       assert Repo.all(<%= inspect context.alias %>.<%= inspect schema.alias %>Token) == []
     end
   end

--- a/priv/templates/phx.gen.auth/context_functions.ex
+++ b/priv/templates/phx.gen.auth/context_functions.ex
@@ -88,7 +88,7 @@
   ## Settings
 
   @doc """
-  Returns an `%Ecto.Changeset{}` for changing the <%= schema.singular %> e-mail.
+  Returns an `%Ecto.Changeset{}` for changing the <%= schema.singular %> email.
 
   ## Examples
 
@@ -101,7 +101,7 @@
   end
 
   @doc """
-  Emulates that the e-mail will change without actually changing
+  Emulates that the email will change without actually changing
   it in the database.
 
   ## Examples
@@ -121,7 +121,7 @@
   end
 
   @doc """
-  Updates the <%= schema.singular %> e-mail in token.
+  Updates the <%= schema.singular %> email in token.
 
   If the token matches, the <%= schema.singular %> email is updated and the token is deleted.
   The confirmed_at date is also updated to the current time.
@@ -147,7 +147,7 @@
   end
 
   @doc """
-  Delivers the update e-mail instructions to the given <%= schema.singular %>.
+  Delivers the update email instructions to the given <%= schema.singular %>.
 
   ## Examples
 
@@ -234,7 +234,7 @@
   ## Confirmation
 
   @doc """
-  Delivers the confirmation e-mail instructions to the given <%= schema.singular %>.
+  Delivers the confirmation email instructions to the given <%= schema.singular %>.
 
   ## Examples
 
@@ -281,7 +281,7 @@
   ## Reset password
 
   @doc """
-  Delivers the reset password e-mail to the given <%= schema.singular %>.
+  Delivers the reset password email to the given <%= schema.singular %>.
 
   ## Examples
 

--- a/priv/templates/phx.gen.auth/notifier.ex
+++ b/priv/templates/phx.gen.auth/notifier.ex
@@ -1,6 +1,6 @@
 defmodule <%= inspect context.module %>.<%= inspect schema.alias %>Notifier do
   # For simplicity, this module simply logs messages to the terminal.
-  # You should replace it by a proper e-mail or notification tool, such as:
+  # You should replace it by a proper email or notification tool, such as:
   #
   #   * Swoosh - https://hexdocs.pm/swoosh
   #   * Bamboo - https://hexdocs.pm/bamboo
@@ -52,7 +52,7 @@ defmodule <%= inspect context.module %>.<%= inspect schema.alias %>Notifier do
   end
 
   @doc """
-  Deliver instructions to update your e-mail.
+  Deliver instructions to update your email.
   """
   def deliver_update_email_instructions(<%= schema.singular %>, url) do
     deliver(<%= schema.singular %>.email, """
@@ -61,7 +61,7 @@ defmodule <%= inspect context.module %>.<%= inspect schema.alias %>Notifier do
 
     Hi #{<%= schema.singular %>.email},
 
-    You can change your e-mail by visiting the url below:
+    You can change your email by visiting the url below:
 
     #{url}
 

--- a/priv/templates/phx.gen.auth/reset_password_controller.ex
+++ b/priv/templates/phx.gen.auth/reset_password_controller.ex
@@ -21,7 +21,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
     conn
     |> put_flash(
       :info,
-      "If your e-mail is in our system, you will receive instructions to reset your password shortly."
+      "If your email is in our system, you will receive instructions to reset your password shortly."
     )
     |> redirect(to: "/")
   end

--- a/priv/templates/phx.gen.auth/reset_password_controller_test.exs
+++ b/priv/templates/phx.gen.auth/reset_password_controller_test.exs
@@ -26,7 +26,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
         })
 
       assert redirected_to(conn) == "/"
-      assert get_flash(conn, :info) =~ "If your e-mail is in our system"
+      assert get_flash(conn, :info) =~ "If your email is in our system"
       assert Repo.get_by!(<%= inspect context.alias %>.<%= inspect schema.alias %>Token, <%= schema.singular %>_id: <%= schema.singular %>.id).context == "reset_password"
     end
 
@@ -37,7 +37,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
         })
 
       assert redirected_to(conn) == "/"
-      assert get_flash(conn, :info) =~ "If your e-mail is in our system"
+      assert get_flash(conn, :info) =~ "If your email is in our system"
       assert Repo.all(<%= inspect context.alias %>.<%= inspect schema.alias %>Token) == []
     end
   end

--- a/priv/templates/phx.gen.auth/schema.ex
+++ b/priv/templates/phx.gen.auth/schema.ex
@@ -17,8 +17,8 @@ defmodule <%= inspect schema.module %> do
   @doc """
   A <%= schema.singular %> changeset for registration.
 
-  It is important to validate the length of both e-mail and password.
-  Otherwise databases may truncate the e-mail without warnings, which
+  It is important to validate the length of both email and password.
+  Otherwise databases may truncate the email without warnings, which
   could lead to unpredictable or insecure behaviour. Long passwords may
   also be very expensive to hash for certain algorithms.
   """
@@ -57,9 +57,9 @@ defmodule <%= inspect schema.module %> do
   end
 
   @doc """
-  A <%= schema.singular %> changeset for changing the e-mail.
+  A <%= schema.singular %> changeset for changing the email.
 
-  It requires the e-mail to change otherwise an error is added.
+  It requires the email to change otherwise an error is added.
   """
   def email_changeset(<%= schema.singular %>, attrs) do
     <%= schema.singular %>

--- a/priv/templates/phx.gen.auth/schema_token.ex
+++ b/priv/templates/phx.gen.auth/schema_token.ex
@@ -6,7 +6,7 @@ defmodule <%= inspect schema.module %>Token do
   @rand_size 32
 
   # It is very important to keep the reset password token expiry short,
-  # since someone with access to the e-mail may take over the account.
+  # since someone with access to the email may take over the account.
   @reset_password_validity_in_days 1
   @confirm_validity_in_days 7
   @change_email_validity_in_days 7
@@ -51,7 +51,7 @@ defmodule <%= inspect schema.module %>Token do
   @doc """
   Builds a token with a hashed counter part.
 
-  The non-hashed token is sent to the <%= schema.singular %> e-mail while the
+  The non-hashed token is sent to the <%= schema.singular %> email while the
   hashed part is stored in the database, to avoid reconstruction.
   The token is valid for a week as long as <%= schema.singular %>s don't change
   their email.

--- a/priv/templates/phx.gen.auth/session_controller.ex
+++ b/priv/templates/phx.gen.auth/session_controller.ex
@@ -14,7 +14,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
     if <%= schema.singular %> = <%= inspect context.alias %>.get_<%= schema.singular %>_by_email_and_password(email, password) do
       <%= inspect schema.alias %>Auth.log_in_<%= schema.singular %>(conn, <%= schema.singular %>, <%= schema.singular %>_params)
     else
-      render(conn, "new.html", error_message: "Invalid e-mail or password")
+      render(conn, "new.html", error_message: "Invalid email or password")
     end
   end
 

--- a/priv/templates/phx.gen.auth/session_controller_test.exs
+++ b/priv/templates/phx.gen.auth/session_controller_test.exs
@@ -62,7 +62,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
 
       response = html_response(conn, 200)
       assert response =~ "<h1>Log in</h1>"
-      assert response =~ "Invalid e-mail or password"
+      assert response =~ "Invalid email or password"
     end
   end
 

--- a/priv/templates/phx.gen.auth/settings_controller.ex
+++ b/priv/templates/phx.gen.auth/settings_controller.ex
@@ -24,7 +24,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
         conn
         |> put_flash(
           :info,
-          "A link to confirm your e-mail change has been sent to the new address."
+          "A link to confirm your email change has been sent to the new address."
         )
         |> redirect(to: Routes.<%= schema.route_helper %>_settings_path(conn, :edit))
 
@@ -37,7 +37,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
     case <%= inspect context.alias %>.update_<%= schema.singular %>_email(conn.assigns.current_<%= schema.singular %>, token) do
       :ok ->
         conn
-        |> put_flash(:info, "E-mail changed successfully.")
+        |> put_flash(:info, "Email changed successfully.")
         |> redirect(to: Routes.<%= schema.route_helper %>_settings_path(conn, :edit))
 
       :error ->

--- a/priv/templates/phx.gen.auth/settings_controller_test.exs
+++ b/priv/templates/phx.gen.auth/settings_controller_test.exs
@@ -67,7 +67,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
         })
 
       assert redirected_to(conn) == Routes.<%= schema.route_helper %>_settings_path(conn, :edit)
-      assert get_flash(conn, :info) =~ "A link to confirm your e-mail"
+      assert get_flash(conn, :info) =~ "A link to confirm your email"
       assert <%= inspect context.alias %>.get_<%= schema.singular %>_by_email(<%= schema.singular %>.email)
     end
 
@@ -100,7 +100,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
     test "updates the <%= schema.singular %> email once", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>, token: token, email: email} do
       conn = get(conn, Routes.<%= schema.route_helper %>_settings_path(conn, :confirm_email, token))
       assert redirected_to(conn) == Routes.<%= schema.route_helper %>_settings_path(conn, :edit)
-      assert get_flash(conn, :info) =~ "E-mail changed successfully"
+      assert get_flash(conn, :info) =~ "Email changed successfully"
       refute <%= inspect context.alias %>.get_<%= schema.singular %>_by_email(<%= schema.singular %>.email)
       assert <%= inspect context.alias %>.get_<%= schema.singular %>_by_email(email)
 

--- a/priv/templates/phx.gen.auth/settings_edit.html.eex
+++ b/priv/templates/phx.gen.auth/settings_edit.html.eex
@@ -1,6 +1,6 @@
 <h1>Settings</h1>
 
-<h3>Change e-mail</h3>
+<h3>Change email</h3>
 
 <%%= form_for @email_changeset, Routes.<%= schema.route_helper %>_settings_path(@conn, :update_email), fn f -> %>
   <%%= if @email_changeset.action do %>
@@ -18,7 +18,7 @@
   <%%= error_tag f, :current_password %>
 
   <div>
-    <%%= submit "Change e-mail" %>
+    <%%= submit "Change email" %>
   </div>
 <%% end %>
 

--- a/priv/templates/phx.gen.auth/test_cases.exs
+++ b/priv/templates/phx.gen.auth/test_cases.exs
@@ -62,19 +62,19 @@
              } = errors_on(changeset)
     end
 
-    test "validates maximum values for e-mail and password for security" do
+    test "validates maximum values for email and password for security" do
       too_long = String.duplicate("db", 100)
       {:error, changeset} = <%= inspect context.alias %>.register_<%= schema.singular %>(%{email: too_long, password: too_long})
       assert "should be at most 160 character(s)" in errors_on(changeset).email
       assert "should be at most 80 character(s)" in errors_on(changeset).password
     end
 
-    test "validates e-mail uniqueness" do
+    test "validates email uniqueness" do
       %{email: email} = <%= schema.singular %>_fixture()
       {:error, changeset} = <%= inspect context.alias %>.register_<%= schema.singular %>(%{email: email})
       assert "has already been taken" in errors_on(changeset).email
 
-      # Now try with the upper cased e-mail too, to check that email case is ignored.
+      # Now try with the upper cased email too, to check that email case is ignored.
       {:error, changeset} = <%= inspect context.alias %>.register_<%= schema.singular %>(%{email: String.upcase(email)})
       assert "has already been taken" in errors_on(changeset).email
     end
@@ -120,7 +120,7 @@
       assert %{email: ["must have the @ sign and no spaces"]} = errors_on(changeset)
     end
 
-    test "validates maximum value for e-mail for security", %{<%= schema.singular %>: <%= schema.singular %>} do
+    test "validates maximum value for email for security", %{<%= schema.singular %>: <%= schema.singular %>} do
       too_long = String.duplicate("db", 100)
 
       {:error, changeset} =
@@ -129,7 +129,7 @@
       assert "should be at most 160 character(s)" in errors_on(changeset).email
     end
 
-    test "validates e-mail uniqueness", %{<%= schema.singular %>: <%= schema.singular %>} do
+    test "validates email uniqueness", %{<%= schema.singular %>: <%= schema.singular %>} do
       %{email: email} = <%= schema.singular %>_fixture()
 
       {:error, changeset} =
@@ -145,7 +145,7 @@
       assert %{current_password: ["is not valid"]} = errors_on(changeset)
     end
 
-    test "applies the e-mail without persisting it", %{<%= schema.singular %>: <%= schema.singular %>} do
+    test "applies the email without persisting it", %{<%= schema.singular %>: <%= schema.singular %>} do
       email = unique_<%= schema.singular %>_email()
       {:ok, <%= schema.singular %>} = <%= inspect context.alias %>.apply_<%= schema.singular %>_email(<%= schema.singular %>, valid_<%= schema.singular %>_password(), %{email: email})
       assert <%= schema.singular %>.email == email
@@ -185,7 +185,7 @@
       %{<%= schema.singular %>: <%= schema.singular %>, token: token, email: email}
     end
 
-    test "updates the e-mail with a valid token", %{<%= schema.singular %>: <%= schema.singular %>, token: token, email: email} do
+    test "updates the email with a valid token", %{<%= schema.singular %>: <%= schema.singular %>, token: token, email: email} do
       assert <%= inspect context.alias %>.update_<%= schema.singular %>_email(<%= schema.singular %>, token) == :ok
       changed_<%= schema.singular %> = Repo.get!(<%= inspect schema.alias %>, <%= schema.singular %>.id)
       assert changed_<%= schema.singular %>.email != <%= schema.singular %>.email
@@ -195,19 +195,19 @@
       refute Repo.get_by(<%= inspect schema.alias %>Token, <%= schema.singular %>_id: <%= schema.singular %>.id)
     end
 
-    test "does not update e-mail with invalid token", %{<%= schema.singular %>: <%= schema.singular %>} do
+    test "does not update email with invalid token", %{<%= schema.singular %>: <%= schema.singular %>} do
       assert <%= inspect context.alias %>.update_<%= schema.singular %>_email(<%= schema.singular %>, "oops") == :error
       assert Repo.get!(<%= inspect schema.alias %>, <%= schema.singular %>.id).email == <%= schema.singular %>.email
       assert Repo.get_by(<%= inspect schema.alias %>Token, <%= schema.singular %>_id: <%= schema.singular %>.id)
     end
 
-    test "does not update e-mail if <%= schema.singular %> e-mail changed", %{<%= schema.singular %>: <%= schema.singular %>, token: token} do
+    test "does not update email if <%= schema.singular %> email changed", %{<%= schema.singular %>: <%= schema.singular %>, token: token} do
       assert <%= inspect context.alias %>.update_<%= schema.singular %>_email(%{<%= schema.singular %> | email: "current@example.com"}, token) == :error
       assert Repo.get!(<%= inspect schema.alias %>, <%= schema.singular %>.id).email == <%= schema.singular %>.email
       assert Repo.get_by(<%= inspect schema.alias %>Token, <%= schema.singular %>_id: <%= schema.singular %>.id)
     end
 
-    test "does not update e-mail if token expired", %{<%= schema.singular %>: <%= schema.singular %>, token: token} do
+    test "does not update email if token expired", %{<%= schema.singular %>: <%= schema.singular %>, token: token} do
       {1, nil} = Repo.update_all(<%= inspect schema.alias %>Token, set: [inserted_at: ~N[2020-01-01 00:00:00]])
       assert <%= inspect context.alias %>.update_<%= schema.singular %>_email(<%= schema.singular %>, token) == :error
       assert Repo.get!(<%= inspect schema.alias %>, <%= schema.singular %>.id).email == <%= schema.singular %>.email
@@ -361,7 +361,7 @@
       %{<%= schema.singular %>: <%= schema.singular %>, token: token}
     end
 
-    test "confirms the e-mail with a valid token", %{<%= schema.singular %>: <%= schema.singular %>, token: token} do
+    test "confirms the email with a valid token", %{<%= schema.singular %>: <%= schema.singular %>, token: token} do
       assert {:ok, confirmed_<%= schema.singular %>} = <%= inspect context.alias %>.confirm_<%= schema.singular %>(token)
       assert confirmed_<%= schema.singular %>.confirmed_at
       assert confirmed_<%= schema.singular %>.confirmed_at != <%= schema.singular %>.confirmed_at
@@ -375,7 +375,7 @@
       assert Repo.get_by(<%= inspect schema.alias %>Token, <%= schema.singular %>_id: <%= schema.singular %>.id)
     end
 
-    test "does not confirm e-mail if token expired", %{<%= schema.singular %>: <%= schema.singular %>, token: token} do
+    test "does not confirm email if token expired", %{<%= schema.singular %>: <%= schema.singular %>, token: token} do
       {1, nil} = Repo.update_all(<%= inspect schema.alias %>Token, set: [inserted_at: ~N[2020-01-01 00:00:00]])
       assert <%= inspect context.alias %>.confirm_<%= schema.singular %>(token) == :error
       refute Repo.get!(<%= inspect schema.alias %>, <%= schema.singular %>.id).confirmed_at


### PR DESCRIPTION
Fixes: #49