### PR TITLE
Enable SameSite protection on remember me cookie

### DIFF
--- a/priv/templates/phx.gen.auth/auth.ex
+++ b/priv/templates/phx.gen.auth/auth.ex
@@ -10,7 +10,7 @@ defmodule <%= inspect auth_module %> do
   # the token expiry itself in <%= inspect schema.alias %>Token.
   @max_age 60 * 60 * 24 * 60
   @remember_me_cookie "<%= schema.singular %>_remember_me"
-  @remember_me_options [sign: true, max_age: @max_age]
+  @remember_me_options [sign: true, max_age: @max_age, same_site: "Lax"]
 
   @doc """
   Logs the <%= schema.singular %> in.


### PR DESCRIPTION
SameSite protection on cookies are rapidly becoming the standard for secure application, so much so that [Firefox will be setting it by default soon](https://hacks.mozilla.org/2020/08/changes-to-samesite-cookie-behavior/). To make sure all users benefit from this protection against CSRF and other such attacks, setting SameSite: Lax on the remember_me cookie would be a good thing.

Be aware that this option was only [added in Plug v1.10.1](https://github.com/elixir-plug/plug/blob/master/CHANGELOG.md#v1101-2020-05-15). Due to the [way it is implemented](https://github.com/elixir-plug/plug/commit/d33694de3e1bdb5a992ae5177a5efed18740b3c2), the `same_site` option simply does nothing if you have an older version of Plug, so it should be fine to add this to the generator, without requiring Plug v1.10.1.