### PR TITLE
maybe_store_return_to handles query string

### DIFF
--- a/priv/templates/phx.gen.auth/auth.ex
+++ b/priv/templates/phx.gen.auth/auth.ex
@@ -139,16 +139,10 @@ defmodule <%= inspect auth_module %> do
     end
   end
 
-  defp maybe_store_return_to(
-         %{method: "GET", request_path: request_path, query_string: ""} = conn
-       ) do
-    put_session(conn, :<%= schema.singular %>_return_to, request_path)
-  end
-
-  defp maybe_store_return_to(
-         %{method: "GET", request_path: request_path, query_string: query_string} = conn
-       ) do
-    put_session(conn, :<%= schema.singular %>_return_to, request_path <> "?" <> query_string)
+  defp maybe_store_return_to(%{method: "GET"} = conn) do
+    %{request_path: request_path, query_string: query_string} = conn
+    return_to = if query_string == "", do: request_path, else: request_path <> "?" <> query_string
+    put_session(conn, :<%= schema.singular %>_return_to, return_to)
   end
 
   defp maybe_store_return_to(conn), do: conn

--- a/priv/templates/phx.gen.auth/auth.ex
+++ b/priv/templates/phx.gen.auth/auth.ex
@@ -139,8 +139,16 @@ defmodule <%= inspect auth_module %> do
     end
   end
 
-  defp maybe_store_return_to(%{method: "GET", request_path: request_path} = conn) do
+  defp maybe_store_return_to(
+         %{method: "GET", request_path: request_path, query_string: ""} = conn
+       ) do
     put_session(conn, :<%= schema.singular %>_return_to, request_path)
+  end
+
+  defp maybe_store_return_to(
+         %{method: "GET", request_path: request_path, query_string: query_string} = conn
+       ) do
+    put_session(conn, :<%= schema.singular %>_return_to, request_path <> "?" <> query_string)
   end
 
   defp maybe_store_return_to(conn), do: conn

--- a/priv/templates/phx.gen.auth/auth_test.exs
+++ b/priv/templates/phx.gen.auth/auth_test.exs
@@ -138,12 +138,20 @@ defmodule <%= inspect auth_module %>Test do
 
     test "stores the path to redirect to on GET", %{conn: conn} do
       halted_conn =
-        %{conn | request_path: "/foo?bar"}
+        %{conn | request_path: "/foo", query_string: ""}
         |> fetch_flash()
         |> <%= inspect schema.alias %>Auth.require_authenticated_<%= schema.singular %>([])
 
       assert halted_conn.halted
-      assert get_session(halted_conn, :<%= schema.singular %>_return_to) == "/foo?bar"
+      assert get_session(halted_conn, :<%= schema.singular %>_return_to) == "/foo"
+
+      halted_conn =
+        %{conn | request_path: "/foo", query_string: "bar=baz"}
+        |> fetch_flash()
+        |> <%= inspect schema.alias %>Auth.require_authenticated_<%= schema.singular %>([])
+
+      assert halted_conn.halted
+      assert get_session(halted_conn, :<%= schema.singular %>_return_to) == "/foo?bar=baz"
 
       halted_conn =
         %{conn | request_path: "/foo?bar", method: "POST"}


### PR DESCRIPTION
Before this change, `maybe_store_return_to` stores the `request_path` attribute of the Plug.Conn, but does not handle the `query_string` if it is present.

Now, we append the `query_string` to the `request_path` if it is present, in order to paths with query strings, and without them.