### PR TITLE
Use current_path instead of reimplementing it

### DIFF
--- a/priv/templates/phx.gen.auth/auth.ex
+++ b/priv/templates/phx.gen.auth/auth.ex
@@ -140,9 +140,7 @@ defmodule <%= inspect auth_module %> do
   end
 
   defp maybe_store_return_to(%{method: "GET"} = conn) do
-    %{request_path: request_path, query_string: query_string} = conn
-    return_to = if query_string == "", do: request_path, else: request_path <> "?" <> query_string
-    put_session(conn, :<%= schema.singular %>_return_to, return_to)
+    put_session(conn, :<%= schema.singular %>_return_to, current_path(conn))
   end
 
   defp maybe_store_return_to(conn), do: conn


### PR DESCRIPTION
It also means we will get this fix in Phoenix v1.6:
https://github.com/phoenixframework/phoenix/issues/4006