### PR TITLE
Update registration create success flash

### DIFF
--- a/priv/templates/phx.gen.auth/registration_controller.ex
+++ b/priv/templates/phx.gen.auth/registration_controller.ex
@@ -20,7 +20,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
           )
 
         conn
-        |> put_flash(:info, "<%= schema.human_singular %> created successfully.")
+        |> put_flash(:info, "Account created successfully.")
         |> <%= inspect schema.alias %>Auth.log_in_<%= schema.singular %>(<%= schema.singular %>)
 
       {:error, %Ecto.Changeset{} = changeset} ->


### PR DESCRIPTION
Changed to match the other messages used, e.g "Account confirmed successfully."

----

Noticed this locally, mine would be "User created successfully." but then referred to as Account when confirming it.  Makes sense tome that it should be referred to consistently.

Thanks for the project, very useful :+1: 