### PR TITLE
Make user enumeration prevention clearer

### DIFF
--- a/guides/overview.md
+++ b/guides/overview.md
@@ -59,14 +59,19 @@ Note that whenever the password changes (either via reset password
 or directly), all tokens are deleted and the user has to log in
 again on all devices.
 
-## Enumeration attacks
+## User Enumeration attacks
 
-An enumeration attack allows an attacker to enumerate all emails
-registered in the application. The generated authentication code
-protects against enumeration attacks on all endpoints, except in
-the registration and update email forms. If your application is
-really sensitive to enumeration attacks, you need to implement
-your own registration workflow, which tends to be very different
+A user enumeration attack allows an attacker to enumerate all emails
+registered in the application. For example, if trying to log in with
+a registered email and a wrong password returns a different error 
+than trying to log in with an email that was never registered, an
+attacker could use this discrepency to find out which emails have 
+accounts.
+
+The generated authentication code protects against enumeration attacks 
+on all endpoints, except in the registration and update email forms. If 
+your application is really sensitive to enumeration attacks, you need to
+implement your own registration workflow, which tends to be very different
 from the workflow for most applications.
 
 ## Case sensitiveness

--- a/priv/templates/phx.gen.auth/confirmation_controller.ex
+++ b/priv/templates/phx.gen.auth/confirmation_controller.ex
@@ -15,7 +15,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
       )
     end
 
-    # Regardless of the outcome, show an impartial success/error message.
+    # In order to prevent user enumeration attacks, regardless of the outcome, show an impartial success/error message.
     conn
     |> put_flash(
       :info,

--- a/priv/templates/phx.gen.auth/reset_password_controller.ex
+++ b/priv/templates/phx.gen.auth/reset_password_controller.ex
@@ -17,7 +17,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
       )
     end
 
-    # Regardless of the outcome, show an impartial success/error message.
+    # In order to prevent user enumeration attacks, regardless of the outcome, show an impartial success/error message.
     conn
     |> put_flash(
       :info,

--- a/priv/templates/phx.gen.auth/session_controller.ex
+++ b/priv/templates/phx.gen.auth/session_controller.ex
@@ -14,6 +14,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
     if <%= schema.singular %> = <%= inspect context.alias %>.get_<%= schema.singular %>_by_email_and_password(email, password) do
       <%= inspect schema.alias %>Auth.log_in_<%= schema.singular %>(conn, <%= schema.singular %>, <%= schema.singular %>_params)
     else
+      # In order to prevent user enumeration attacks, don't discolose whether the email is registered.
       render(conn, "new.html", error_message: "Invalid email or password")
     end
   end


### PR DESCRIPTION
Following up from a conversation in #elixir-lang on IRC today, this PR clarifies the docs a little bit about what enumeration attacks are, and adds a bit more detail to the generated comments so that the reader knows what to google when they come across this code.

I also changed the name to "User Enumeration." In my experience I've seen this attack called "user enumeration" or "account enumeration" (e.g. see https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html for example usage). I think enumeration on it's own implies *something* is being enumerated but it doesn't make clear what it is.
