### PR TITLE
Use argon2 as default over bcrypt.

### DIFF
--- a/lib/mix/phx_gen_auth/hashing_library.ex
+++ b/lib/mix/phx_gen_auth/hashing_library.ex
@@ -3,6 +3,20 @@ defmodule Mix.Phx.Gen.Auth.HashingLibrary do
 
   defstruct [:module, :mix_dependency, :test_config]
 
+  def build("argon2") do
+    lib = %__MODULE__{
+      module: Argon2,
+      mix_dependency: ~s|{:argon2_elixir, "~> 2.0\"}|,
+      test_config: """
+      config :argon2_elixir,
+        t_cost: 1,
+        m_cost: 8
+      """
+    }
+
+    {:ok, lib}
+  end
+
   def build("bcrypt") do
     lib = %__MODULE__{
       module: Bcrypt,
@@ -21,20 +35,6 @@ defmodule Mix.Phx.Gen.Auth.HashingLibrary do
       mix_dependency: ~s|{:pbkdf2_elixir, "~> 1.0\"}|,
       test_config: """
       config :pbkdf2_elixir, :rounds, 1
-      """
-    }
-
-    {:ok, lib}
-  end
-
-  def build("argon2") do
-    lib = %__MODULE__{
-      module: Argon2,
-      mix_dependency: ~s|{:argon2_elixir, "~> 2.0\"}|,
-      test_config: """
-      config :argon2_elixir,
-        t_cost: 1,
-        m_cost: 8
       """
     }
 

--- a/lib/mix/phx_gen_auth/hashing_library.ex
+++ b/lib/mix/phx_gen_auth/hashing_library.ex
@@ -3,20 +3,6 @@ defmodule Mix.Phx.Gen.Auth.HashingLibrary do
 
   defstruct [:module, :mix_dependency, :test_config]
 
-  def build("argon2") do
-    lib = %__MODULE__{
-      module: Argon2,
-      mix_dependency: ~s|{:argon2_elixir, "~> 2.0\"}|,
-      test_config: """
-      config :argon2_elixir,
-        t_cost: 1,
-        m_cost: 8
-      """
-    }
-
-    {:ok, lib}
-  end
-
   def build("bcrypt") do
     lib = %__MODULE__{
       module: Bcrypt,
@@ -35,6 +21,20 @@ defmodule Mix.Phx.Gen.Auth.HashingLibrary do
       mix_dependency: ~s|{:pbkdf2_elixir, "~> 1.0\"}|,
       test_config: """
       config :pbkdf2_elixir, :rounds, 1
+      """
+    }
+
+    {:ok, lib}
+  end
+
+  def build("argon2") do
+    lib = %__MODULE__{
+      module: Argon2,
+      mix_dependency: ~s|{:argon2_elixir, "~> 2.0\"}|,
+      test_config: """
+      config :argon2_elixir,
+        t_cost: 1,
+        m_cost: 8
       """
     }
 

--- a/lib/mix/tasks/phx.gen.auth.ex
+++ b/lib/mix/tasks/phx.gen.auth.ex
@@ -13,16 +13,16 @@ defmodule Mix.Tasks.Phx.Gen.Auth do
 
   ## Password hashing
 
-  The password hashing mechanism defaults to `bcrypt` for
+  The password hashing mechanism defaults to `argon2` for
   Unix systems and `pbkdf2` for Windows systems. Both
   systems use [the Comeonin interface](https://hexdocs.pm/comeonin/).
 
   The password hashing mechanism can be overriden with the
   `--hashing-lib` option. The following values are supported:
 
+  * `argon2` - [argon2_elixir](https://hex.pm/packages/argon2_elixir)
   * `bcrypt` - [bcrypt_elixir](https://hex.pm/packages/bcrypt_elixir)
   * `pbkdf2` - [pbkdf2_elixir](https://hex.pm/packages/pbkdf2_elixir)
-  * `argon2` - [argon2_elixir](https://hex.pm/packages/argon2_elixir)
 
   For more information about choosing these libraries, see the
   [Comeonin project](https://github.com/riverrun/comeonin).
@@ -192,7 +192,7 @@ defmodule Mix.Tasks.Phx.Gen.Auth do
 
   defp default_hashing_library_option do
     case :os.type() do
-      {:unix, _} -> "bcrypt"
+      {:unix, _} -> "argon2"
       {:win32, _} -> "pbkdf2"
     end
   end
@@ -676,9 +676,9 @@ defmodule Mix.Tasks.Phx.Gen.Auth do
 
     mix phx.gen.auth supports the following values for --hashing-lib
 
+      * argon2
       * bcrypt
       * pbkdf2
-      * argon2
 
     Visit https://github.com/riverrun/comeonin for more information
     on choosing a library.

--- a/test/mix/tasks/phx.gen.auth_test.exs
+++ b/test/mix/tasks/phx.gen.auth_test.exs
@@ -84,7 +84,7 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
       )
 
       assert_file("config/test.exs", fn file ->
-        assert file =~ "config :bcrypt_elixir, :log_rounds, 1"
+        assert file =~ "config :argon2_elixir, :log_rounds, 1"
       end)
 
       assert_file("lib/my_app/accounts.ex")
@@ -129,7 +129,7 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
       end)
 
       assert_file("mix.exs", fn file ->
-        assert file =~ ~s|{:bcrypt_elixir, "~> 2.0"},|
+        assert file =~ ~s|{:argon2_elixir, "~> 2.0"},|
       end)
 
       assert_file("lib/my_app_web/router.ex", fn file ->

--- a/test/mix/tasks/phx_gen_auth/integration_tests/default_app_test.exs
+++ b/test/mix/tasks/phx_gen_auth/integration_tests/default_app_test.exs
@@ -19,7 +19,7 @@ defmodule Phx.Gen.Auth.IntegrationTests.DefaultAppTest do
     mix_run!(~w(phx.gen.auth Accounts User users), cd: test_app_path)
 
     assert_file(Path.join(test_app_path, "config/test.exs"), fn file ->
-      assert file =~ "config :bcrypt_elixir, :log_rounds, 1"
+      assert file =~ "config :argon2_elixir, :log_rounds, 1"
     end)
 
     assert_file(Path.join(test_app_path, "lib/demo/accounts/user.ex"), fn file ->


### PR DESCRIPTION
Why is this change necessary?
------------------------------

When this generator was first created Bcrypt was still the OWASP recommended default choice https://github.com/dashbitco/mix_phx_gen_auth_demo/pull/1#discussion_r403110955

That has [since changed](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html) and argon2 is now the officially recommended choice, with bcrypt only being recommended if argon2 is not available.

This PR swaps the default from bcrypt to argon2.

Should we also default Windows to argon2? <- I don't know and so I left it.

<Details>

I generated a sample phx project and configured it to look at this local copy of phx_gen_auth.

<img width="374" alt="Screen Shot 2021-04-22 at 7 08 44 AM" src="https://user-images.githubusercontent.com/8015081/115712631-9e0cc600-a33a-11eb-95f5-c2b10ff5714e.png">

Ran the command with no `hashing-lib` specified.

<img width="334" alt="Screen Shot 2021-04-22 at 7 09 02 AM" src="https://user-images.githubusercontent.com/8015081/115712673-a82ec480-a33a-11eb-9d27-553f3a21958b.png">

It uses argon2 lib.

<img width="826" alt="Screen Shot 2021-04-22 at 7 10 24 AM" src="https://user-images.githubusercontent.com/8015081/115712701-b11f9600-a33a-11eb-8615-ea273ef2f18d.png">

The tests are green.

</Details>